### PR TITLE
feat(matches): enforce unique team matchups

### DIFF
--- a/apps/matches/models.py
+++ b/apps/matches/models.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.db.models import CheckConstraint, F, Q, UniqueConstraint
+from django.db.models.functions import Greatest, Least
 
 from apps.core.models import SoftDeleteModel, TimeStampedModel
 from apps.events.models import Event, EventTeam
@@ -57,10 +58,14 @@ class TeamMatch(BaseMatch):
                 name='%(app_label)s_%(class)s_check_team_a_ne_team_b',
                 violation_error_message='Team A and Team B must be different.',
             ),
+            # e04有地雷！！！
+            # postgreSQL Lease Greatest: 回傳 non-null 的最小/最大值，若全都 null 回傳 null
+            # SQLite Oracle MySQl : Lease Greatest 如果有任何 expression 是 null 回傳 null
             UniqueConstraint(
-                fields=['number'],
-                name='%(app_label)s_%(class)s_unique_number',
-                violation_error_message='Team match number must be unique',
+                Least('team_a', 'team_b'),
+                Greatest('team_a', 'team_b'),
+                name='%(app_label)s_%(class)s_unique_matchup',
+                violation_error_message='This team matchup already exists in the system.',
             ),
         ]
 


### PR DESCRIPTION
- Add `unique_matchup` constraint to `TeamMatch` model using `Least` and `Greatest` functions to prevent duplicate pairings (e.g., A vs B and B vs A).
- Add validation in `MatchService.initialize_team_match` to ensure match numbers are unique within an event.
- Note potential database compatibility issues with `Least`/`Greatest` handling of NULL values (documented in code).





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces unique team matchups and ensures match numbers are unique per event, with a Redis lock to prevent race conditions during creation.

- **New Features**
  - Add DB-level unique constraint using Least/Greatest on team_a/team_b to treat (A,B) and (B,A) as the same matchup.
  - Add per-event match number check in initialize_team_match, protected by a Redis distributed lock (with fallback when lock is unavailable).
  - Document DB differences for Least/Greatest with NULLs (Postgres vs SQLite/MySQL).

<sup>Written for commit 8e7f222095bc9ef9baa06ef62fcda67e53e0c0ee. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate team pairings regardless of team order; users now see "This team matchup already exists in the system." when attempting a duplicate.

* **Chores**
  * Added a creation safeguard to avoid race conditions during match creation; if creation is contended, users receive a localized "system busy" validation error and the system falls back to a safe creation path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->