### PR TITLE
Revert "📝 Add docstrings to `feat/lunch-order-system`"

### DIFF
--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -102,14 +102,6 @@ class EventTeamMember(TimeStampedModel):
         return f'{self.user.full_name} in ({self.event_team})'
 
     def clean(self):
-        """
-        Validate that the associated user is not already assigned to a different team for the same event.
-        
-        If the related event cannot be determined (missing relation or deleted), validation is skipped. Raises a ValidationError when another EventTeamMember exists for the same event and user, excluding this instance.
-         
-        Raises:
-            ValidationError: If the user is already registered in another team for the event.
-        """
         try:
             event = self.event_team.event
         except (ObjectDoesNotExist, AttributeError, ValueError):
@@ -128,12 +120,6 @@ class LunchOption(TimeStampedModel):
     name = models.CharField(max_length=64)
 
     def __str__(self):
-        """
-        Provide a human-readable representation of the lunch option including its event.
-        
-        Returns:
-            str: The lunch option formatted as "<name> (<event_name>)".
-        """
         return f'{self.name} ({self.event.name})'
 
 
@@ -146,10 +132,4 @@ class RegistrationLunchOrder(TimeStampedModel):
     note = models.TextField(default='', blank=True)
 
     def __str__(self):
-        """
-        Provide a human-readable representation of the lunch order.
-        
-        Returns:
-            A string in the format "<member.user.full_name>: <quantity> x <option.name>" representing the ordering member, the quantity ordered, and the lunch option.
-        """
         return f'{self.member.user.full_name}: {self.quantity} x {self.option.name}'

--- a/apps/events/services.py
+++ b/apps/events/services.py
@@ -28,15 +28,13 @@ class EventService:
         lunch_options: list[str] = None,
     ) -> Event:
         """
-        Create an Event and, if provided, create associated LunchOption records for it.
-        
-        If `lunch_options` is provided, a LunchOption is created for each name in the list and linked to the created event.
-        
-        Parameters:
-            lunch_options (list[str], optional): Names of lunch options to create and associate with the event.
-        
-        Returns:
-            Event: The created Event instance.
+        Creates a new event with the specified type.
+            name: The name of the event.
+            event_type: One of Event.TypeChoices (e.g., 'TN', 'LG', 'FR').
+            start_time: (Optional) Datetime object.
+            end_time: (Optional) Datetime object.
+            location: (Optional) Location instance.
+            lunch_options: (Optional) List of lunch option names.
         """
 
         event = Event(
@@ -58,21 +56,11 @@ class EventService:
         *, member: EventTeamMember, lunch_orders: list[dict] = None
     ) -> list[RegistrationLunchOrder]:
         """
-        Create registration lunch orders for an EventTeamMember from provided order descriptions.
-        
-        Each entry in `lunch_orders` must reference a lunch option that belongs to the member's event. When valid orders are provided, corresponding RegistrationLunchOrder records are created in bulk.
-        
-        Parameters:
-            lunch_orders (list[dict] | None): Optional list of order dictionaries. Each dictionary should contain:
-                - 'option_id' (int): ID of a LunchOption belonging to the event.
-                - 'quantity' (int, optional): Number of portions (defaults to 1).
-                - 'note' (str, optional): Free-text note for the order (defaults to empty string).
-        
-        Returns:
-            list[RegistrationLunchOrder]: The list of created RegistrationLunchOrder instances; empty if no orders were created.
-        
-        Raises:
-            ValidationError: If any provided `option_id` does not belong to the member's event.
+        Creates lunch orders for a specific event team member.
+        lunch_orders example: [
+            {'option_id': 1, 'quantity': 2, 'note': 'No spicy'},
+            {'option_id': 2, 'quantity': 1, 'note': 'Extra water'}
+        ]
         """
         created_orders = []
 
@@ -105,18 +93,7 @@ class EventService:
         *, event: Event, team: Team, status=EventTeam.StatusChoices.APPROVED
     ) -> EventTeam:
         """
-        Register a team for an event.
-        
-        Parameters:
-            event (Event): Event to register the team for.
-            team (Team): Team being registered.
-            status (EventTeam.StatusChoices | str): Registration status to assign; defaults to EventTeam.StatusChoices.APPROVED.
-        
-        Returns:
-            EventTeam: The created EventTeam registration record.
-        
-        Raises:
-            ValidationError: If the team is already registered for the event or the created record fails validation.
+        Registers a team to an event.
         """
         try:
             event_team = EventTeam(
@@ -136,22 +113,9 @@ class EventService:
         *, event_team: EventTeam, user, is_player=True, is_coach=False, is_staff=False
     ) -> EventTeamMember:
         """
-        Add a user to an EventTeam roster.
-        
-        Acquires a row-level lock on the user to prevent concurrent cross-team registrations, validates the new roster membership, and saves it.
-        
-        Parameters:
-            event_team (EventTeam): The team registration to add the user to.
-            user (User): The user to add to the roster.
-            is_player (bool): Whether the user is a player on the team.
-            is_coach (bool): Whether the user is a coach on the team.
-            is_staff (bool): Whether the user is staff for the team.
-        
-        Returns:
-            EventTeamMember: The created EventTeamMember instance.
-        
-        Raises:
-            ValidationError: If the membership is invalid (model validation) or the user is already in the team's roster.
+        Adds a user to a specific EventTeam roster.
+        Uses select_for_update on the user to prevent concurrent registrations
+        across different teams in the same event.
         """
         try:
             # Lock the user record to prevent race conditions during cross-team validation


### PR DESCRIPTION
Reverts FriedDinoEggs/Nexus#18

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the recent docstring additions in the lunch‑order system. Removes verbose docstrings from apps/events/models.py and simplifies those in apps/events/services.py; no functional changes.

<sup>Written for commit 0303a7c95649c1cf3cecd7aab7415bb279215cd1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

