### PR TITLE
fix(events): fix nested lunch option creation

### DIFF
--- a/apps/events/serializers.py
+++ b/apps/events/serializers.py
@@ -94,7 +94,7 @@ class EventTeamSerializer(serializers.ModelSerializer):
 
 
 class LunchOptionSerializer(serializers.ModelSerializer):
-    event = PrimaryKeyRelatedField(queryset=LunchOption.objects.all(), required=False)
+    event = PrimaryKeyRelatedField(queryset=Event.objects.all(), required=False)
 
     class Meta:
         model = LunchOption

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import get_user_model
-from rest_framework import permissions, status, viewsets
+from rest_framework import permissions, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.views import Response
 
@@ -63,7 +63,12 @@ class LunchOptionsViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer) -> None:
         event_id_nested = self.kwargs.get('event_id', None)
         if event_id_nested:
-            event = Event.objects.get(pk=event_id_nested)
+            try:
+                event = Event.objects.get(pk=event_id_nested)
+            except Exception as e:
+                raise serializers.ValidationError(
+                    {'event_id': f'event_id: {event_id_nested} not found', 'detail': f'{str(e)}'}
+                ) from None
             serializer.save(event=event)
         else:
             serializer.save()


### PR DESCRIPTION
- Update `LunchOptionSerializer` to use `PrimaryKeyRelatedField` for the event field.
- Implement `perform_create` in `LunchOptionsViewSet` to automatically associate lunch options with an event when using nested routes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix creating lunch options via nested routes by auto-linking them to the parent event. The serializer now accepts an event ID and supports nested creates without requiring the field in the payload.

- **Bug Fixes**
  - Auto-associate the event in LunchOptionsViewSet.perform_create when event_id is in the route, and raise a validation error if the event is not found.
  - Update LunchOptionSerializer to use PrimaryKeyRelatedField with an Event queryset for event and make it optional for nested requests.

<sup>Written for commit 8cc77cb68cbe27a7a828ec1b60df4c887abc1013. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Lunch options now include an optional linked event reference in their public data.
  * Creating a lunch option via an event-specific endpoint will automatically associate it with that event when present, and returns a clear validation error if the referenced event is not found.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->