### PR TITLE
test(events): include user ID in EventTeamMemberSerializer test data

### DIFF
--- a/apps/events/tests_serializers.py
+++ b/apps/events/tests_serializers.py
@@ -33,7 +33,7 @@ class TestEventTeamMemberSerializer(APITestCase):
         EventTeamMember.objects.create(event_team=self.event_team1, user=self.user)
 
         # Try to register for another team in same event
-        data = {'event_team': self.event_team2.id}
+        data = {'user': self.user.id, 'event_team': self.event_team2.id}
         serializer = EventTeamMemberSerializer(data=data, context={'request': self.request})
 
         self.assertTrue(serializer.is_valid(), serializer.errors)
@@ -59,7 +59,7 @@ class TestEventTeamMemberSerializer(APITestCase):
         self.assertTrue(serializer.is_valid(), serializer.errors)
 
     def test_create_works_as_expected(self):
-        data = {'event_team': self.event_team1.id, 'is_player': True}
+        data = {'user': self.user.id, 'event_team': self.event_team1.id, 'is_player': True}
         serializer = EventTeamMemberSerializer(data=data, context={'request': self.request})
 
         self.assertTrue(serializer.is_valid(), serializer.errors)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add user ID to EventTeamMemberSerializer test inputs. Aligns tests with serializer requirements and keeps duplicate registration validation and create behavior passing.

<sup>Written for commit e3cfbc78754e8c3d9efc1b18f33a4745ef06532e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test data for event team member registration scenarios to ensure proper validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->