### PR TITLE
chore(infra): add nginx configuration for load balancing and reverse …

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,30 @@
+upstream my_cluster {
+    server 127.0.0.1:8081 max_fails=1 fail_timeout=10s;
+    server 127.0.0.1:8082 max_fails=1 fail_timeout=10s;
+}
+
+server {
+	listen 80;
+
+	server_name $tt_domain;
+
+	set_real_ip_from 127.0.0.1;
+	real_ip_header X-Forwarded-For;
+	location /admin {
+		allow 127.0.0.1;
+	    
+		deny all; 
+
+		proxy_pass http://my_cluster;
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+	}
+
+	location / {
+		proxy_pass http://my_cluster;
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+	}
+}


### PR DESCRIPTION
…proxy

- Configure upstream 'my_cluster' with two local servers
- Set up server block for ${DOMAIN} on port 80
- Restrict access to /admin to localhost only
- Configure proxy headers for real IP tracking

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Nginx config to load balance and reverse proxy traffic on port 80. Routes to two local app servers, locks /admin to localhost, and forwards real client IPs.

- **New Features**
  - Upstream my_cluster with 127.0.0.1:8081 and 127.0.0.1:8082 (basic failover).
  - Server block for $tt_domain on port 80; all routes proxy to upstream.
  - /admin accessible only from 127.0.0.1; others denied.
  - Real IP tracking via X-Forwarded-For and standard proxy headers.

<sup>Written for commit e335a1146a6646b3f0c3ee1f1cb207203dce1491. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured load balancing infrastructure with multiple backend services
  * Implemented access control for administrative endpoints (restricted to localhost)
  * Established traffic routing and proxy configurations with standard header forwarding

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->