### PR TITLE
refactor(users): simplify JWT logout logic and reorder operations

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -269,11 +269,11 @@ class CustomJWTLogoutView(TokenBlacklistView):
     authentication_classes = [CustomJWTAuthentication]
 
     def post(self, request, *args, **kwargs):
-        access_token = request.auth
-        if access_token is not None:
+        resp = super().post(request, *args, **kwargs)
+        if resp.status_code < 400:
+            access_token = request.auth
             BlackListService.set_blacklisted(token=access_token, user=request.user)
-
-        return super().post(request, *args, **kwargs)
+        return resp
 
 
 class IPBaseThrottle(SimpleRateThrottle):


### PR DESCRIPTION
The `CustomJWTLogoutView.post` method was refactored to call `super().post()` first, capturing its response before manually blacklisting the access token. This ensures that the refresh token is processed by the base library logic before the access token is handled. Additionally, the redundant null check for `access_token` was removed as the view requires authentication.

- Capture response from `super().post()`
- Remove redundant null check for `access_token`
- Reorder operations to ensure refresh token blacklisting happens first

fixes #49 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified JWT logout flow by calling the base TokenBlacklistView first to process the refresh token, capturing its response, then blacklisting the access token. Removed the redundant access_token None check since the view requires authentication.

<sup>Written for commit f7b3fde33232fa8893a89524df08336db172e24f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined logout flow to call the underlying logout once and return that response.

* **Bug Fixes**
  * Blacklisting of the session now occurs only when the logout completes successfully, preventing unnecessary blacklist attempts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->