### PR TITLE
feat(users): add password validation to registration serializer

### DIFF
--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -2,6 +2,7 @@ import secrets
 from dataclasses import asdict
 
 from django.contrib.auth import authenticate, get_user_model
+from django.contrib.auth.password_validation import validate_password as django_validate_password
 from rest_framework import serializers
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework_simplejwt.serializers import (
@@ -72,6 +73,10 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
     def validate(self, attrs):
         if attrs['password'] != attrs['password_confirm']:
             raise serializers.ValidationError({'password_confirm': 'Passwords do not match'})
+        return attrs
+
+    def validate_password(self, attrs):
+        django_validate_password(attrs, self.instance)
         return attrs
 
     def validate_date_of_birth(self, attrs):


### PR DESCRIPTION
Integrated Django's built-in password validation into `UserRegistrationSerializer` to enforce password security policies during user registration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Django’s built-in password validation to UserRegistrationSerializer to enforce password strength during sign-up. Implemented a validate_password field validator that calls django.contrib.auth.password_validation.validate_password and surfaces relevant errors to the user.

<sup>Written for commit 573a89882892ff6ba88215135c89e5f084475e1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Password validation is now enforced during user registration using Django's built-in security standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->