### PR TITLE
refactor(events): require explicit rule configuration in EventRuleConfigSerializer

### DIFF
--- a/apps/events/serializers.py
+++ b/apps/events/serializers.py
@@ -19,25 +19,25 @@ from .services import EventService
 
 class EventRuleConfigSerializer(serializers.Serializer):
     winning_sets = serializers.IntegerField(
-        default=3, help_text='Number of sets to win a PlayerMatch'
+        required=True, help_text='Number of sets to win a PlayerMatch'
     )
     set_winning_points = serializers.IntegerField(
-        default=11, help_text='Points needed to win a single set'
+        required=True, help_text='Points needed to win a single set'
     )
     use_deuce = serializers.BooleanField(
-        default=True, help_text='Whether to use deuce rule (must win by 2 points)'
+        required=True, help_text='Whether to use deuce rule (must win by 2 points)'
     )
     team_winning_points = serializers.IntegerField(
-        default=3, help_text='Number of points (matches) to win a TeamMatch'
+        required=True, help_text='Number of points (matches) to win a TeamMatch'
     )
     play_all_sets = serializers.BooleanField(
-        default=False, help_text='Must play all sets, overrides winning_sets setting'
+        required=True, help_text='Must play all sets, overrides winning_sets setting'
     )
     play_all_matches = serializers.BooleanField(
-        default=False, help_text='Must play all matches, overrides team_winning_points setting'
+        required=True, help_text='Must play all matches, overrides team_winning_points setting'
     )
     count_points_by_sets = serializers.BooleanField(
-        default=False, help_text='Whether to count set scores (e.g. 4:2) or win/loss (1:0)'
+        required=True, help_text='Whether to count set scores (e.g. 4:2) or win/loss (1:0)'
     )
 
 


### PR DESCRIPTION
Remove default values for match and set rules in `EventRuleConfigSerializer` and set them as required. This ensures that all event configurations are explicitly defined by the caller, preventing accidental reliance on hardcoded defaults.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require explicit configuration for all event rule fields in EventRuleConfigSerializer by removing defaults. This prevents unintended rule behavior and makes API requests fully declarative.

- **Migration**
  - Send all rule fields when creating/updating events: winning_sets, set_winning_points, use_deuce, team_winning_points, play_all_sets, play_all_matches, count_points_by_sets.
  - Update forms and tests to provide values; missing fields now fail validation.
  - Replace any reliance on prior defaults (e.g., 3 sets, 11 points, deuce on) with explicit values.

<sup>Written for commit aca45cebdee45e1c971b7a7f55717523d5ca6ffd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Event rule configuration now requires all settings to be explicitly provided instead of using defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->