### PR TITLE
chore(docker): update healthcheck endpoint to /api/v1/health/

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -44,7 +44,7 @@ USER nexus
 EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:8000/api/schema/ || exit 1
+  CMD curl -f http://localhost:8000/api/v1/health/ || exit 1
 
 # Default command: Run with Granian
 CMD ["granian", "config.wsgi:application", \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the API Docker healthcheck to use /api/v1/health/ instead of /api/schema/, ensuring the container checks a dedicated health endpoint and reducing false failures.

<sup>Written for commit 6e5670c40ebaac8c8699c2451f293ee755622a2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API health check configuration to improve deployment reliability and container monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->