### PR TITLE
feat(core): add OpenAPI schema and HEAD method to health check

### DIFF
--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import OpenApiTypes, extend_schema
 from rest_framework import status, views
 from rest_framework.permissions import AllowAny
 from rest_framework.views import Response
@@ -6,5 +7,18 @@ from rest_framework.views import Response
 class health(views.APIView):
     permission_classes = [AllowAny]
 
+    @extend_schema(
+        responses={200: OpenApiTypes.NONE},
+        methods=['GET'],
+        auth=[],
+    )
     def get(self, request):
+        return Response(status=status.HTTP_200_OK)
+
+    @extend_schema(
+        responses={200: OpenApiTypes.NONE},
+        methods=['HEAD'],
+        auth=[],
+    )
+    def head(self, request):
         return Response(status=status.HTTP_200_OK)


### PR DESCRIPTION
- Add `drf_spectacular` schema decorators to health check endpoint
- Implement `HEAD` method for health check
- Configure OpenAPI documentation for health check methods

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a HEAD method to the health check and annotated both GET and HEAD with drf-spectacular for OpenAPI docs. This enables lightweight health probes and makes the endpoint clear in the API spec.

- **New Features**
  - HEAD returns 200 with no body.
  - OpenAPI schema for GET and HEAD (no auth, empty response).

<sup>Written for commit 1403d08f1ee3fa480b806b946d35981f38d62bdd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced API schema documentation for better integration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->