### PR TITLE
docs(api): add OpenAPI schema tags and parameters to viewsets

### DIFF
--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -4,6 +4,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.views import Response
 
 
+@extend_schema(tags=['v1', 'Core'])
 class health(views.APIView):
     permission_classes = [AllowAny]
 

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from drf_spectacular.utils import extend_schema
 from rest_framework import permissions, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.views import Response
@@ -23,6 +24,7 @@ from .services import EventService
 User = get_user_model()
 
 
+@extend_schema(tags=['v1', 'Events'])
 class MatchTemplateViewSet(viewsets.ModelViewSet):
     queryset = EventMatchTemplate.objects.all().prefetch_related('items')
 
@@ -39,6 +41,7 @@ class MatchTemplateViewSet(viewsets.ModelViewSet):
         return super().get_permissions()
 
 
+@extend_schema(tags=['v1', 'Events'])
 class EventViewSet(viewsets.ModelViewSet):
     queryset = (
         Event.objects.all()
@@ -56,6 +59,7 @@ class EventViewSet(viewsets.ModelViewSet):
         return super().get_permissions()
 
 
+@extend_schema(tags=['v1', 'Events'])
 class LunchOptionsViewSet(viewsets.ModelViewSet):
     queryset = LunchOption.objects.all().select_related('event')
     serializer_class = LunchOptionSerializer
@@ -92,6 +96,7 @@ class LunchOptionsViewSet(viewsets.ModelViewSet):
             serializer.save()
 
 
+@extend_schema(tags=['v1', 'Events'])
 class EventTeamViewSet(viewsets.ModelViewSet):
     queryset = EventTeam.objects.all().select_related('event', 'team', 'coach', 'leader')
     serializer_class = EventTeamSerializer
@@ -149,6 +154,7 @@ class EventTeamViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
+@extend_schema(tags=['v1', 'Events'])
 class EventTeamMemberViewSet(viewsets.ModelViewSet):
     queryset = (
         EventTeamMember.objects.all()

--- a/apps/matches/views.py
+++ b/apps/matches/views.py
@@ -1,4 +1,6 @@
 from django.db.models import Q
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import permissions, viewsets
 
 from apps.users.permissions import IsEventManagerGroup
@@ -7,6 +9,17 @@ from .models import TeamMatch
 from .serializers import TeamMatchSerializer
 
 
+@extend_schema(
+    tags=['v1', 'Matches'],
+    parameters=[
+        OpenApiParameter(
+            name='event_team_id',
+            type=OpenApiTypes.INT,
+            location=OpenApiParameter.PATH,
+            description='其中一隊伍的 ID',
+        ),
+    ],
+)
 class TeamMatchViewSet(viewsets.ModelViewSet):
     queryset = (
         TeamMatch.objects.all()

--- a/apps/teams/views.py
+++ b/apps/teams/views.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework import permissions, viewsets
 
 from apps.teams.serializers import TeamSerializer
@@ -6,6 +7,7 @@ from apps.users.permissions import IsEventManagerGroup, IsSuperAdminGroup
 from .models import Team
 
 
+@extend_schema(tags=['v1', 'Teams'])
 class TeamViewSet(viewsets.ModelViewSet):
     queryset = Team.objects.all()
     serializer_class = TeamSerializer

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -127,6 +127,7 @@ class UserProfileViewSet(viewsets.ModelViewSet):
         instance.save()
 
 
+@extend_schema(tags=['v1', 'Users'])
 class UserVerificationViewSet(viewsets.GenericViewSet):
     authentication_classes = [CustomJWTAuthentication]
     permission_classes = [IsAuthenticated]
@@ -193,6 +194,7 @@ class UserVerificationViewSet(viewsets.GenericViewSet):
         return Response(status=status.HTTP_400_BAD_REQUEST)
 
 
+@extend_schema(tags=['v1', 'Users'])
 class UserResetPasswordViewSet(viewsets.GenericViewSet):
     permission_classes = [AllowAny]
     serializer_class = UserPasswordResetSerializer
@@ -263,7 +265,7 @@ class GoogleLoginViewSet(viewsets.GenericViewSet):
         )
 
 
-@extend_schema(tags=['v1', 'users'])
+@extend_schema(tags=['v1', 'Users'])
 class CustomJWTLogoutView(TokenBlacklistView):
     permission_classes = [IsAuthenticated]
     authentication_classes = [CustomJWTAuthentication]

--- a/config/settings.py
+++ b/config/settings.py
@@ -189,7 +189,7 @@ REST_FRAMEWORK = {
 
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Nexus Project API',
-    'DESCRIPTION': '龍濱會員賽事系統',
+    'DESCRIPTION': '會員賽事系統',
     'VERSION': '0.0.1',
     'SERVE_INCLUDE_SCHEMA': False,
 
@@ -215,7 +215,11 @@ SPECTACULAR_SETTINGS = {
                 }
             }
         }
-    }
+    },
+    'ENUM_NAME_OVERRIDES': {
+        'EventTeamStatusEnum': 'apps.events.models.EventTeam.StatusChoices',
+        'MatchStatusEnum': 'apps.matches.models.BaseMatch.StatusChoices',
+    },
 }
 
 SIMPLE_JWT = {


### PR DESCRIPTION
- Add 'v1' and functional tags (Core, Events, Matches, Teams, Users) to viewsets for improved documentation categorization.
- Add explicit path parameter documentation for `event_team_id` in `TeamMatchViewSet`.
- Import and apply `drf-spectacular`'s `extend_schema` decorator across multiple apps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenAPI tags and parameter docs to improve Swagger UI grouping and clarity. Also standardizes enum names and schema metadata.

- **New Features**
  - Tag all viewsets with ['v1', '<Area>'] for Core, Events, Matches, Teams, Users using extend_schema.
  - Document event_team_id as an int PATH parameter in TeamMatchViewSet.
  - Update drf-spectacular settings: add ENUM_NAME_OVERRIDES for EventTeam.StatusChoices and BaseMatch.StatusChoices, refine API description, and normalize Users tag capitalization.

<sup>Written for commit 8eff34c327638f16691129f1d9389847fd7821f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user verification and password reset endpoints for account management

* **Documentation**
  * Enhanced API documentation with improved schema organization, detailed parameter descriptions, and standardized categorization
  * Updated API description text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->