### PR TITLE
Hot fix/redis connectivity issue

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,6 +16,9 @@ PGADMIN_PWD=
 REDIS_LOCATION=redis://127.0.0.1:6379/4
 REDIS_PASSWORD=
 
+CELERY_BROKER_URL=redis://: <nexus_redis_password >@localhost:6379/2
+CELERY_RESULT_BACKEND=redis://: <redis_password >@localhost:6379/3
+
 MAILTRAP_KEY=
 MAILTRAP_DOMAIN=
 MAILTRAP_INBOX_ID=

--- a/apps/users/services/services.py
+++ b/apps/users/services/services.py
@@ -51,7 +51,7 @@ class UserVerificationServices:
             base_url = settings.SITE_BASEURL
 
         base_url.rstrip('/')
-        path = reverse('v1:users_app:password-reset-verify')
+        path = reverse('v1:users_app:email-verification-verify')
 
         param = {'mode': 'verifyEmail', 'code': token}
 

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -8,8 +8,11 @@ x-django-template: &django-base
   environment:
     - NEXUS_DB_HOST=pg_db_prod
     - NEXUS_DB_PORT=5432
-    - REDIS_LOCATION=redis://redis_prod:6379/1
+    - REDIS_LOCATION=redis://:${REDIS_PASSWORD}@redis_prod:6379/1
     - DEBUG=False
+    - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD}@redis_prod:6379/2
+    - CELERY_RESULT_BACKEND=redis://:${REDIS_PASSWORD}@redis_prod:6379/3
+
   depends_on:
     postgres:
       condition: service_healthy
@@ -83,7 +86,7 @@ services:
         --save 300 10
         --save 60 10000
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 10s
       timeout: 3s
       retries: 5

--- a/config/settings.py
+++ b/config/settings.py
@@ -235,8 +235,14 @@ SIMPLE_JWT = {
 CELERY_TIMEZONE = 'Asia/Taipei'
 CELERY_TASK_TRACK_STARTED = True
 CELERY_TASK_TIME_LIMIT = 30 * 60
-CELERY_BROKER_URL = f'redis://:{os.environ["REDIS_PASSWORD"]}@localhost:6379/2'
-CELERY_RESULT_BACKEND = f'redis://:{os.environ["REDIS_PASSWORD"]}@localhost:6379/3'
+CELERY_BROKER_URL = os.environ.get(
+    'CELERY_BROKER_URL',
+    f'redis://:{os.environ["REDIS_PASSWORD"]}@localhost:6380/2'
+)
+CELERY_RESULT_BACKEND = os.environ.get(
+    'CELERY_RESULT_BACKEND',
+    f'redis://:{os.environ["REDIS_PASSWORD"]}@localhost:6380/3'
+)
 CELERY_RESULT_EXPIRES = 60*60
 
 # Mailtrap


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Redis connectivity in production by adding password-authenticated Redis URLs and env-based Celery config. Also fixes the email verification link routing to the correct endpoint.

- **Bug Fixes**
  - Add REDIS_PASSWORD to Redis URIs and healthcheck in compose.prod.yaml.
  - Read CELERY_BROKER_URL and CELERY_RESULT_BACKEND from env with secure defaults; fallback port set to 6380 when unset.
  - Use the correct reverse name: v1:users_app:email-verification-verify.

- **Migration**
  - Set REDIS_PASSWORD in all environments.
  - Provide CELERY_BROKER_URL and CELERY_RESULT_BACKEND in prod; otherwise ensure Redis is reachable at localhost:6380.

<sup>Written for commit 7d111813846a76d88a0497a9e46ae3ee701ddcfa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

