### PR TITLE
fix(celery): improve healthcheck reliability and reduce timeout in production

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -130,7 +130,11 @@ services:
     image: celery-image:${GIT_TAG:-latest}
     command: celery -A config worker -l INFO --concurrency 2
     healthcheck:
-      test: ["CMD-SHELL", "celery -A config inspect ping --timeout 10"]
+      test:
+        [
+          "CMD-SHELL",
+          "celery -A config inspect ping -d celery@$$HOSTNAME --timeout 5 || exit 1",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
…oduction

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the production Celery worker healthcheck for reliability and quicker failure detection. It now pings the local worker and uses a 5s timeout.

- **Bug Fixes**
  - Healthcheck targets the current worker: celery@$HOSTNAME.
  - Timeout reduced from 10s to 5s; exits non-zero on failed ping to avoid false positives.

<sup>Written for commit c262b55cfa35bce39a5c2887171b6d8a1e21da5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Celery worker health check configuration to verify host-specific worker status with a reduced timeout, enabling faster detection of worker failures in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->