### PR TITLE
Feat/calendar support

### DIFF
--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -1,3 +1,5 @@
+from datetime import datetime, time
+
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -30,6 +32,15 @@ class Event(SoftDeleteModel):
     )
     start_time = models.DateTimeField(null=True, blank=True)
     end_time = models.DateTimeField(null=True, blank=True)
+
+    @property
+    def all_day(self) -> bool:
+        if self.start_time and self.end_time:
+            midnight = time(0, 0)
+            is_midnight = self.start_time.time() == midnight and self.end_time.time() == midnight
+            is_oneday_diff = (self.end_time - self.start_time) == datetime.timedelta(days=1)
+            return bool(is_midnight and is_oneday_diff)
+        return False
 
     class Meta:
         default_manager_name = SoftDeleteModel.Meta.default_manager_name

--- a/apps/events/serializers.py
+++ b/apps/events/serializers.py
@@ -169,6 +169,7 @@ class EventSerializer(serializers.ModelSerializer):
             'name',
             'start_time',
             'end_time',
+            'all_day',
             'type',
             'location_name',
             'event_teams',

--- a/apps/events/serializers.py
+++ b/apps/events/serializers.py
@@ -277,3 +277,11 @@ class EventMatchTemplateSerializer(serializers.ModelSerializer):
         return EventService.update_match_template(
             template=instance, name=validated_data.get('name'), items_data=items_data
         )
+
+
+class EventCalendarSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    title = serializers.CharField(source='name')
+    start = serializers.DateTimeField(source='start_time')
+    end = serializers.DateTimeField(source='end_time')
+    allDay = serializers.BooleanField(source='all_day')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds calendar view support to the Events API with a compact serializer and date-range filtering. Also adds an all_day flag for true all-day events.

- **New Features**
  - Event.all_day computed when start/end are midnight and span 24 hours; exposed in EventSerializer.
  - New EventCalendarSerializer with fields: id, title (name), start, end, allDay.
  - EventViewSet: ?calendar=true enables calendar mode, filters by overlapping start/end params, returns unpaginated results, and selects the lightweight serializer.

<sup>Written for commit 5a3239040808a68746d20e78f71be457db6a01f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added all-day event detection—events are marked as all-day when start and end times are set to midnight with a one-day span.
  * Introduced calendar-based event querying with optional date range filtering for efficient calendar display.
  * Optimized event serialization for calendar views with renamed fields for compatibility.
  * Disabled pagination for calendar queries to support full event range display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->