### PR TITLE
chore(config): disable prometheus migration export

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -348,6 +348,6 @@ LOGGING = {
 # Django Prometheus Settings
 # Define latency buckets (in seconds) to enable p95/p99 histograms for DB queries
 PROMETHEUS_LATENCY_BUCKETS = (.008, .016, .032, .064, .128, .256, .512, 1.024, 2.048, 4.096, 8.192, 16.384, 32.768, 65.536, 131.072, 262.144, 524.288, 1048.576)
-PROMETHEUS_EXPORT_MIGRATIONS = True
+PROMETHEUS_EXPORT_MIGRATIONS = False
 
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable Prometheus migration export by setting `PROMETHEUS_EXPORT_MIGRATIONS` to `False`. This removes noisy, short‑lived metrics during deploys and reduces scrape load.

<sup>Written for commit 306a3a7d6f638ac316e13440f5a0f072d09daada. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted monitoring export configuration setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->