### PR TITLE
feat(users): include id in UserRegistrationSerializer

### DIFF
--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -34,6 +34,7 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = [
+            'id',
             'email',
             'password',
             'password_confirm',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return the user ID after registration by adding `id` to the `UserRegistrationSerializer` fields. This lets clients reference the new user immediately (e.g., for redirects or linking profiles).

<sup>Written for commit 50a119c7887f607c30c3f0f0ba2f5d82a85394ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User registration responses now include the user ID upon successful registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->