### PR TITLE
feat: parameterize Grafana Prometheus datasource

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -169,7 +169,6 @@ services:
       postgres:
         condition: service_healthy
 
-
   prometheus:
     image: prom/prometheus:latest
     container_name: prometheus_prod
@@ -200,6 +199,8 @@ services:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:?error}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?error}
       GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_IS_DEFAULT_PROD: "false"
+
     volumes:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning/datasources/prometheus.prod.yml:/etc/grafana/provisioning/datasources/prometheus.yml:ro

--- a/compose.yaml
+++ b/compose.yaml
@@ -154,6 +154,7 @@ services:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:?error}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?error}
       GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_IS_DEFAULT_PROD: "false"
     volumes:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro

--- a/monitoring/grafana/provisioning/datasources/prometheus.prod.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.prod.yml
@@ -6,5 +6,5 @@ datasources:
     uid: DS_PROMETHEUS
     access: proxy
     url: http://prometheus_prod:9090
-    isDefault: true
+    isDefault: ${GF_IS_DEFAULT_PROD}
     editable: false

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -5,5 +5,5 @@ datasources:
     type: prometheus
     access: proxy
     url: http://prometheus:9090
-    isDefault: true
+    isDefault: ${GF_IS_DEFAULT_PROD}
     editable: false


### PR DESCRIPTION
- Add GF_IS_DEFAULT_PROD env var to docker-compose files.
- Update Grafana provisioning to use variable for datasource isDefault setting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parameterizes Grafana’s Prometheus datasource `isDefault` using the `GF_IS_DEFAULT_PROD` env var. Lets us toggle the default datasource per environment without editing provisioning files.

- **New Features**
  - Adds `GF_IS_DEFAULT_PROD` to `compose.yaml` and `compose.prod.yaml` (default "false").
  - Sets `isDefault: ${GF_IS_DEFAULT_PROD}` in `monitoring/grafana/provisioning/datasources/prometheus*.yml`.

- **Migration**
  - Set `GF_IS_DEFAULT_PROD=true` in environments where Prometheus should be the default, then restart Grafana.

<sup>Written for commit 4d501560c53d9ad2dda007d9e5c2d59944851bc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grafana configuration updated to enable environment-based control of the Prometheus datasource's default status. Changes to deployment configurations and datasource provisioning files allow different default datasource settings for development and production environments, supporting more flexible deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->