### PR TITLE
Feat/bruno user integration tests

### DIFF
--- a/nexus_integration_test/04.getUsersWithJWT.yml
+++ b/nexus_integration_test/04.getUsersWithJWT.yml
@@ -12,19 +12,23 @@ http:
 
 runtime:
   scripts:
-    - type: after-response
+    - type: before-request
       code: |-
         const axios = require('axios');
 
         try {
-          const response = await axios.post('http://127.0.0.1:8000/api/v1/users/login/',{
-            email: 'testAdmin@test.com',
-            password: 'testAdmin'
-          });
-          bru.setVar('jwt_access', response.data.access);
+          const response = await axios.post(
+            'http://127.0.0.1:8000/api/v1/users/login/',{
+              email: 'testAdmin@test.com',
+              password: 'testAdmin'
+            }
+          );
+          bru.setVar("jwt_access", response.data.access);
         } catch(error) {
           console.error("error code", error.response.status);
         }
+    - type: after-response
+      code: bru.setVar("jwt_access", null);
   assertions:
     - expression: res.status
       operator: eq

--- a/nexus_integration_test/04.getUsersWithoutJWT.yml
+++ b/nexus_integration_test/04.getUsersWithoutJWT.yml
@@ -10,9 +10,6 @@ http:
     - name: ""
       value: ""
       type: query
-  auth:
-    type: bearer
-    token: ""
 
 runtime:
   assertions:

--- a/nexus_integration_test/06.getMyProfile.yml
+++ b/nexus_integration_test/06.getMyProfile.yml
@@ -1,0 +1,42 @@
+info:
+  name: 06.getMyProfile
+  type: http
+  seq: 8
+
+http:
+  method: GET
+  url: 127.0.0.1:8000/api/v1/users/me/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',{
+            email: 'testMember@test.com',
+            password: 'testMember'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "200"
+    - expression: res.body.email
+      operator: eq
+      value: testMember@test.com
+    - expression: res.body.id
+      operator: isNumber
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/07.updateMyProfile.yml
+++ b/nexus_integration_test/07.updateMyProfile.yml
@@ -1,0 +1,63 @@
+info:
+  name: 07.updateMyProfile
+  type: http
+  seq: 9
+
+http:
+  method: PATCH
+  url: 127.0.0.1:8000/api/v1/users/me/
+  body:
+    type: json
+    data: |-
+      {
+        "full_name": "Member Updated"
+      }
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',{
+            email: 'testMember@test.com',
+            password: 'testMember'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const axios = require("axios");
+        const token = bru.getVar("jwt_access")
+
+        const response = await axios.patch(
+          'http://127.0.0.1:8000/api/v1/users/me/',
+          { full_name: "Member"},
+          {
+            headers: {
+              "Authorization": `Bearer ${token}`
+            } 
+          }
+        );
+
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "200"
+    - expression: res.body.full_name
+      operator: eq
+      value: Member Updated
+    - expression: res.body.email
+      operator: eq
+      value: testMember@test.com
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/08.refreshToken.yml
+++ b/nexus_integration_test/08.refreshToken.yml
@@ -1,0 +1,45 @@
+info:
+  name: 08.refreshToken
+  type: http
+  seq: 10
+
+http:
+  method: POST
+  url: 127.0.0.1:8000/api/v1/users/refresh/
+  body:
+    type: json
+    data: |-
+      {
+        "refresh": "{{jwt_refresh}}"
+      }
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',{
+            email: 'testAdmin@test.com',
+            password: 'testAdmin'
+          }
+        );
+        bru.setVar("jwt_refresh", response.data.refresh);
+    - type: after-response
+      code: |-
+        bru.setVar("jwt_refresh", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "200"
+    - expression: res.body.access
+      operator: isNotEmpty
+    - expression: res.body.access_token
+      operator: isNotEmpty
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/09.logout.yml
+++ b/nexus_integration_test/09.logout.yml
@@ -1,0 +1,46 @@
+info:
+  name: 09.logout
+  type: http
+  seq: 11
+
+http:
+  method: POST
+  url: 127.0.0.1:8000/api/v1/users/logout/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+  body:
+    type: json
+    data: |-
+      {
+        "refresh": "{{jwt_refresh}}"
+      }
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',{
+            email: 'testAdmin@test.com',
+            password: 'testAdmin'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+        bru.setVar("jwt_refresh", response.data.refresh);
+    - type: after-response
+      code: |-
+        bru.setVar("jwt_access", null);
+        bru.setVar("jwt_refresh", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "200"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/10.registerPasswordMismatch.yml
+++ b/nexus_integration_test/10.registerPasswordMismatch.yml
@@ -1,0 +1,30 @@
+info:
+  name: 10.registerPasswordMismatch
+  type: http
+  seq: 12
+
+http:
+  method: POST
+  url: 127.0.0.1:8000/api/v1/users/register/
+  body:
+    type: json
+    data: |-
+      {
+        "email": "test-mismatch@test.com",
+        "password": "dkizxs32c",
+        "password_confirm": "dkizxs32d"
+      }
+
+runtime:
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "400"
+    - expression: res.body.password_confirm
+      operator: isNotEmpty
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/11.deleteUserForbidden.yml
+++ b/nexus_integration_test/11.deleteUserForbidden.yml
@@ -1,0 +1,61 @@
+info:
+  name: 11.deleteUserForbidden
+  type: http
+  seq: 13
+
+http:
+  method: DELETE
+  url: 127.0.0.1:8000/api/v1/users/{{target_user_id}}/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const adminLogin = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',{
+            email: 'testAdmin@test.com',
+            password: 'testAdmin'
+          }
+        );
+        const usersResponse = await axios.get(
+          'http://127.0.0.1:8000/api/v1/users/',
+          {
+            headers: {
+              Authorization: `Bearer ${adminLogin.data.access}`
+            }
+          }
+        );
+        const users = usersResponse.data.results || usersResponse.data;
+        const adminUser = users.find((user) => user.email === 'testAdmin@test.com');
+        if (!adminUser) {
+          throw new Error('Admin user not found');
+        }
+
+        const memberLogin = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',{
+            email: 'testMember@test.com',
+            password: 'testMember'
+          }
+        );
+
+        bru.setVar("target_user_id", adminUser.id);
+        bru.setVar("jwt_access", memberLogin.data.access);
+    - type: after-response
+      code: |-
+        bru.setVar("target_user_id", null);
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "403"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/12.getUsersAsManager.yml
+++ b/nexus_integration_test/12.getUsersAsManager.yml
@@ -1,0 +1,50 @@
+info:
+  name: 12.getUsersAsManager
+  type: http
+  seq: 14
+
+http:
+  method: GET
+  url: 127.0.0.1:8000/api/v1/users/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',{
+            email: 'testEventManager@test.com',
+            password: 'testEventManager'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const data = res.getBody();
+        const users = data.results || data;
+        const adminUser = users.find((user) => user.full_name === 'SuperAdmin');
+        const memberUser = users.find((user) => user.full_name === 'Member');
+
+        if (!adminUser || adminUser.email !== 'testAdmin@test.com') {
+          throw new Error('Manager should see admin email');
+        }
+        if (!memberUser || memberUser.email !== 'testMember@test.com') {
+          throw new Error('Manager should see member email');
+        }
+
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "200"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/13.getUsersAsMember.yml
+++ b/nexus_integration_test/13.getUsersAsMember.yml
@@ -1,0 +1,50 @@
+info:
+  name: 13.getUsersAsMember
+  type: http
+  seq: 15
+
+http:
+  method: GET
+  url: 127.0.0.1:8000/api/v1/users/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',{
+            email: 'testMember@test.com',
+            password: 'testMember'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const data = res.getBody();
+        const users = data.results || data;
+        const adminUser = users.find((user) => user.full_name === 'SuperAdmin');
+        const memberUser = users.find((user) => user.full_name === 'Member');
+
+        if (!adminUser || adminUser.email !== undefined) {
+          throw new Error('Member should not see admin email');
+        }
+        if (!memberUser || memberUser.email !== 'testMember@test.com') {
+          throw new Error('Member should see own email');
+        }
+
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "200"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/14.accessTokenRejectedAfterLogout.yml
+++ b/nexus_integration_test/14.accessTokenRejectedAfterLogout.yml
@@ -1,0 +1,50 @@
+info:
+  name: 14.accessTokenRejectedAfterLogout
+  type: http
+  seq: 16
+
+http:
+  method: GET
+  url: 127.0.0.1:8000/api/v1/users/me/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const loginResponse = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',{
+            email: 'testAdmin@test.com',
+            password: 'testAdmin'
+          }
+        );
+
+        bru.setVar("jwt_access", loginResponse.data.access);
+
+        await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/logout/',
+          {
+            refresh: loginResponse.data.refresh
+          },
+          {
+            headers: {
+              Authorization: `Bearer ${loginResponse.data.access}`
+            }
+          }
+        );
+    - type: after-response
+      code: bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "401"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/15.refreshWithoutToken.yml
+++ b/nexus_integration_test/15.refreshWithoutToken.yml
@@ -1,0 +1,26 @@
+info:
+  name: 15.refreshWithoutToken
+  type: http
+  seq: 17
+
+http:
+  method: POST
+  url: 127.0.0.1:8000/api/v1/users/refresh/
+  body:
+    type: json
+    data: |-
+      {}
+
+runtime:
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "400"
+    - expression: res.body.refresh
+      operator: isNotEmpty
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/16.refreshWithInvalidToken.yml
+++ b/nexus_integration_test/16.refreshWithInvalidToken.yml
@@ -1,0 +1,26 @@
+info:
+  name: 16.refreshWithInvalidToken
+  type: http
+  seq: 18
+
+http:
+  method: POST
+  url: 127.0.0.1:8000/api/v1/users/refresh/
+  body:
+    type: json
+    data: |-
+      {
+        "refresh": "not-a-valid-jwt"
+      }
+
+runtime:
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "401"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/17.memberCannotPatchOtherUser.yml
+++ b/nexus_integration_test/17.memberCannotPatchOtherUser.yml
@@ -1,0 +1,68 @@
+info:
+  name: 17.memberCannotPatchOtherUser
+  type: http
+  seq: 19
+
+http:
+  method: PATCH
+  url: 127.0.0.1:8000/api/v1/users/{{target_user_id}}/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+  body:
+    type: json
+    data: |-
+      {
+        "full_name": "Should Not Work"
+      }
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const adminLogin = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',{
+            email: 'testAdmin@test.com',
+            password: 'testAdmin'
+          }
+        );
+        const usersResponse = await axios.get(
+          'http://127.0.0.1:8000/api/v1/users/',
+          {
+            headers: {
+              Authorization: `Bearer ${adminLogin.data.access}`
+            }
+          }
+        );
+        const users = usersResponse.data.results || usersResponse.data;
+        const adminUser = users.find((user) => user.email === 'testAdmin@test.com');
+
+        if (!adminUser) {
+          throw new Error('Admin user not found');
+        }
+
+        const memberLogin = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',{
+            email: 'testMember@test.com',
+            password: 'testMember'
+          }
+        );
+
+        bru.setVar("target_user_id", adminUser.id);
+        bru.setVar("jwt_access", memberLogin.data.access);
+    - type: after-response
+      code: |-
+        bru.setVar("target_user_id", null);
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "403"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/18.managerCanPatchMember.yml
+++ b/nexus_integration_test/18.managerCanPatchMember.yml
@@ -1,0 +1,80 @@
+info:
+  name: 18.managerCanPatchMember
+  type: http
+  seq: 20
+
+http:
+  method: PATCH
+  url: 127.0.0.1:8000/api/v1/users/{{target_user_id}}/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+  body:
+    type: json
+    data: |-
+      {
+        "full_name": "Managed Member"
+      }
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const managerLogin = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',{
+            email: 'testEventManager@test.com',
+            password: 'testEventManager'
+          }
+        );
+        const usersResponse = await axios.get(
+          'http://127.0.0.1:8000/api/v1/users/',
+          {
+            headers: {
+              Authorization: `Bearer ${managerLogin.data.access}`
+            }
+          }
+        );
+        const users = usersResponse.data.results || usersResponse.data;
+        const memberUser = users.find((user) => user.email === 'testMember@test.com');
+
+        if (!memberUser) {
+          throw new Error('Member user not found');
+        }
+
+        bru.setVar("target_user_id", memberUser.id);
+        bru.setVar("jwt_access", managerLogin.data.access);
+    - type: after-response
+      code: |-
+        const axios = require('axios');
+        const token = bru.getVar("jwt_access");
+        const targetUserId = bru.getVar("target_user_id");
+
+        if (token && targetUserId) {
+          await axios.patch(
+            `http://127.0.0.1:8000/api/v1/users/${targetUserId}/`,
+            { full_name: 'Member' },
+            {
+              headers: {
+                Authorization: `Bearer ${token}`
+              }
+            }
+          );
+        }
+
+        bru.setVar("target_user_id", null);
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "200"
+    - expression: res.body.full_name
+      operator: eq
+      value: Managed Member
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/19.ownerCanPatchSelfById.yml
+++ b/nexus_integration_test/19.ownerCanPatchSelfById.yml
@@ -1,0 +1,77 @@
+info:
+  name: 19.ownerCanPatchSelfById
+  type: http
+  seq: 21
+
+http:
+  method: PATCH
+  url: 127.0.0.1:8000/api/v1/users/{{self_user_id}}/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+  body:
+    type: json
+    data: |-
+      {
+        "full_name": "Owner Updated"
+      }
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const memberLogin = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',{
+            email: 'testMember@test.com',
+            password: 'testMember'
+          }
+        );
+        const meResponse = await axios.get(
+          'http://127.0.0.1:8000/api/v1/users/me/',
+          {
+            headers: {
+              Authorization: `Bearer ${memberLogin.data.access}`
+            }
+          }
+        );
+
+        bru.setVar("self_user_id", meResponse.data.id);
+        bru.setVar("jwt_access", memberLogin.data.access);
+    - type: after-response
+      code: |-
+        const axios = require('axios');
+        const token = bru.getVar("jwt_access");
+        const userId = bru.getVar("self_user_id");
+
+        if (token && userId) {
+          await axios.patch(
+            `http://127.0.0.1:8000/api/v1/users/${userId}/`,
+            { full_name: 'Member' },
+            {
+              headers: {
+                Authorization: `Bearer ${token}`
+              }
+            }
+          );
+        }
+
+        bru.setVar("self_user_id", null);
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "200"
+    - expression: res.body.full_name
+      operator: eq
+      value: Owner Updated
+    - expression: res.body.email
+      operator: eq
+      value: testMember@test.com
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/20.registerWeakPassword.yml
+++ b/nexus_integration_test/20.registerWeakPassword.yml
@@ -1,0 +1,30 @@
+info:
+  name: 20.registerWeakPassword
+  type: http
+  seq: 22
+
+http:
+  method: POST
+  url: 127.0.0.1:8000/api/v1/users/register/
+  body:
+    type: json
+    data: |-
+      {
+        "email": "test-weak-password@test.com",
+        "password": "12345678",
+        "password_confirm": "12345678"
+      }
+
+runtime:
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "400"
+    - expression: res.body.password
+      operator: isNotEmpty
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/21.registerDuplicateEmail.yml
+++ b/nexus_integration_test/21.registerDuplicateEmail.yml
@@ -1,0 +1,30 @@
+info:
+  name: 21.registerDuplicateEmail
+  type: http
+  seq: 23
+
+http:
+  method: POST
+  url: 127.0.0.1:8000/api/v1/users/register/
+  body:
+    type: json
+    data: |-
+      {
+        "email": "testMember@test.com",
+        "password": "dkizxs32c",
+        "password_confirm": "dkizxs32c"
+      }
+
+runtime:
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "400"
+    - expression: res.body.email
+      operator: isNotEmpty
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/22.registerTooYoung.yml
+++ b/nexus_integration_test/22.registerTooYoung.yml
@@ -1,0 +1,31 @@
+info:
+  name: 22.registerTooYoung
+  type: http
+  seq: 24
+
+http:
+  method: POST
+  url: 127.0.0.1:8000/api/v1/users/register/
+  body:
+    type: json
+    data: |-
+      {
+        "email": "test-too-young@test.com",
+        "password": "dkizxs32c",
+        "password_confirm": "dkizxs32c",
+        "date_of_birth": "2023-03-24"
+      }
+
+runtime:
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "400"
+    - expression: res.body.date_of_birth
+      operator: isNotEmpty
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/23.registerTooOld.yml
+++ b/nexus_integration_test/23.registerTooOld.yml
@@ -1,0 +1,31 @@
+info:
+  name: 23.registerTooOld
+  type: http
+  seq: 25
+
+http:
+  method: POST
+  url: 127.0.0.1:8000/api/v1/users/register/
+  body:
+    type: json
+    data: |-
+      {
+        "email": "test-too-old@test.com",
+        "password": "dkizxs32c",
+        "password_confirm": "dkizxs32c",
+        "date_of_birth": "1900-01-01"
+      }
+
+runtime:
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "400"
+    - expression: res.body.date_of_birth
+      operator: isNotEmpty
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds comprehensive Bruno integration tests for user auth, profiles, and role-based permissions to increase coverage and catch regressions. Also updates existing tests to isolate JWT state and reflect expected unauthenticated behavior.

- **New Features**
  - Tests for profile: GET/PATCH `/users/me/`, including owner updating self by ID.
  - Auth flow tests: refresh success, refresh without/invalid token, logout, and access token rejection post-logout.
  - Registration validations: password mismatch, weak password, duplicate email, and age bounds.
  - RBAC: manager can patch member; member cannot patch others; member cannot delete admin.
  - Listing visibility: manager sees emails for others; member sees only own email.

- **Refactors**
  - Move logins to before-request and clear `jwt_access`/`jwt_refresh` after-response to prevent state leakage.
  - Remove bearer config from the “without JWT” test to ensure true unauthenticated access.
  - Update `04.getUsersWithJWT.yml` to initialize/clear JWTs consistently.

<sup>Written for commit a952880d1e4b2692edcaba123a90cf664473573d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded integration test coverage for user authentication flows including login, logout, and token refresh.
  * Added validation tests for user registration covering password requirements, age restrictions, and duplicate account prevention.
  * Enhanced authorization testing for role-based access control, user profile management, and permission boundaries.
  * Improved test coverage for token management and post-logout access denial.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->