### PR TITLE
test(users): add Django service, serializer, and API view coverage

### DIFF
--- a/apps/users/tests.py
+++ b/apps/users/tests.py
@@ -1,0 +1,278 @@
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.core.cache import cache
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+from rest_framework.exceptions import ValidationError
+from rest_framework_simplejwt.tokens import AccessToken
+
+from apps.users.models import BlackListToken
+from apps.users.serializers import UserProfileSerializer, UserRegistrationSerializer
+from apps.users.services import BlackListService, UserVerificationServices
+
+User = get_user_model()
+
+
+class BaseUsersTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+        self.superadmin_group, _ = Group.objects.get_or_create(name='SuperAdmin')
+        self.manager_group, _ = Group.objects.get_or_create(name='EventManager')
+        self.member_group, _ = Group.objects.get_or_create(name='Member')
+
+    def make_user(self, *, email, password='password123', full_name='User', groups=None, **extra):
+        user = User.objects.create_user(
+            email=email,
+            password=password,
+            full_name=full_name,
+            **extra,
+        )
+        if groups is not None:
+            user.groups.set(groups)
+        return user
+
+    def make_request(self, user):
+        request = self.factory.get('/api/v1/users/')
+        request.user = user
+        return request
+
+
+class UserRegistrationSerializerTests(BaseUsersTestCase):
+    def test_superadmin_can_see_is_active_field(self):
+        user = self.make_user(
+            email='admin@test.com',
+            full_name='Admin',
+            groups=[self.superadmin_group],
+        )
+        serializer = UserRegistrationSerializer(context={'request': self.make_request(user)})
+
+        self.assertIn('is_active', serializer.fields)
+
+    def test_non_superadmin_cannot_see_is_active_field(self):
+        user = self.make_user(
+            email='member@test.com',
+            full_name='Member',
+            groups=[self.member_group],
+        )
+        serializer = UserRegistrationSerializer(context={'request': self.make_request(user)})
+
+        self.assertNotIn('is_active', serializer.fields)
+
+    def test_validate_rejects_password_mismatch(self):
+        user = self.make_user(
+            email='member@test.com',
+            full_name='Member',
+            groups=[self.member_group],
+        )
+        serializer = UserRegistrationSerializer(
+            data={
+                'email': 'new@test.com',
+                'password': 'StrongPass123!@#',
+                'password_confirm': 'StrongPass123!@4',
+            },
+            context={'request': self.make_request(user)},
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('password_confirm', serializer.errors)
+
+    def test_validate_date_of_birth_rejects_out_of_range_age(self):
+        user = self.make_user(
+            email='member@test.com',
+            full_name='Member',
+            groups=[self.member_group],
+        )
+        serializer = UserRegistrationSerializer(context={'request': self.make_request(user)})
+
+        with self.assertRaises(ValidationError):
+            serializer.validate_date_of_birth(date.today().replace(year=date.today().year - 3))
+
+        with self.assertRaises(ValidationError):
+            serializer.validate_date_of_birth(date(1900, 1, 1))
+
+
+class UserProfileSerializerTests(BaseUsersTestCase):
+    def setUp(self):
+        super().setUp()
+        self.admin = self.make_user(
+            email='admin@test.com',
+            full_name='Admin',
+            groups=[self.superadmin_group],
+        )
+        self.manager = self.make_user(
+            email='manager@test.com',
+            full_name='Manager',
+            groups=[self.manager_group],
+        )
+        self.member = self.make_user(
+            email='member@test.com',
+            full_name='Member',
+            groups=[self.member_group],
+            date_of_birth=date(2000, 1, 1),
+        )
+
+    def test_superadmin_sees_full_user_profile_fields(self):
+        serializer = UserProfileSerializer(
+            self.member,
+            context={'request': self.make_request(self.admin)},
+        )
+
+        self.assertEqual(
+            set(serializer.data.keys()),
+            {'id', 'email', 'full_name', 'date_of_birth', 'avatar', 'is_active'},
+        )
+
+    def test_manager_sees_other_user_email_but_not_date_of_birth(self):
+        serializer = UserProfileSerializer(
+            self.member,
+            context={'request': self.make_request(self.manager)},
+        )
+
+        self.assertIn('email', serializer.data)
+        self.assertNotIn('date_of_birth', serializer.data)
+        self.assertNotIn('is_active', serializer.data)
+
+    def test_member_cannot_see_other_user_email(self):
+        other_member = self.make_user(
+            email='other@test.com',
+            full_name='Other Member',
+            groups=[self.member_group],
+        )
+        serializer = UserProfileSerializer(
+            other_member,
+            context={'request': self.make_request(self.member)},
+        )
+
+        self.assertEqual(set(serializer.data.keys()), {'id', 'full_name', 'avatar'})
+
+    def test_owner_sees_private_fields_on_own_profile(self):
+        serializer = UserProfileSerializer(
+            self.member,
+            context={'request': self.make_request(self.member)},
+        )
+
+        self.assertIn('email', serializer.data)
+        self.assertIn('date_of_birth', serializer.data)
+        self.assertNotIn('is_active', serializer.data)
+
+
+class UserVerificationServicesTests(BaseUsersTestCase):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+        self.user = self.make_user(
+            email='verify@test.com',
+            full_name='Verify User',
+            groups=[self.member_group],
+            is_verified=False,
+        )
+
+    @patch('apps.users.services.services.send_unified_mail_task.delay')
+    @patch('apps.users.services.services.uuid6.uuid7')
+    def test_send_verification_mail_stores_cache_and_sends_mail(self, mock_uuid7, mock_delay):
+        mock_uuid7.return_value = SimpleNamespace(hex='verifytoken')
+
+        UserVerificationServices.send_verification_mail(
+            user=self.user,
+            base_url='http://127.0.0.1:8000/',
+        )
+
+        self.assertEqual(
+            cache.get(f'{UserVerificationServices.cache_verify_header}verifytoken'),
+            self.user.id,
+        )
+        mock_delay.assert_called_once_with(
+            mail_type='verify',
+            verification_url='http://127.0.0.1:8000/api/v1/verification/verify/?mode=verifyEmail&code=verifytoken',
+            to=self.user.email,
+        )
+
+    @patch('apps.users.services.services.send_unified_mail_task.delay')
+    def test_verify_mail_marks_user_verified_and_consumes_token(self, mock_delay):
+        cache.set(
+            f'{UserVerificationServices.cache_verify_header}verifytoken', self.user.id, timeout=60
+        )
+
+        result = UserVerificationServices.verify_mail(token='verifytoken')
+
+        self.user.refresh_from_db()
+        self.assertEqual(result, 1)
+        self.assertTrue(self.user.is_verified)
+        self.assertIsNone(cache.get(f'{UserVerificationServices.cache_verify_header}verifytoken'))
+        mock_delay.assert_called_once_with(mail_type='welcome', to=self.user.email)
+
+    @patch('apps.users.services.services.send_unified_mail_task.delay')
+    @patch('apps.users.services.services.random.randint', return_value=123456)
+    def test_send_reset_pwd_mail_stores_code_and_sends_mail(self, mock_randint, mock_delay):
+        UserVerificationServices.send_reset_pwd_mail(account=self.user.email)
+
+        self.assertEqual(
+            cache.get(self.user.email),
+            f'{UserVerificationServices.cache_reset_pwd_header}123456',
+        )
+        mock_randint.assert_called_once()
+        mock_delay.assert_called_once_with(
+            mail_type='reset_pwd',
+            code='123456',
+            to=self.user.email,
+        )
+
+    def test_verify_reset_pwd_returns_true_once_then_consumes_code(self):
+        cache.set(
+            self.user.email,
+            f'{UserVerificationServices.cache_reset_pwd_header}654321',
+            timeout=60,
+        )
+
+        self.assertTrue(
+            UserVerificationServices.verify_reset_pwd(
+                code='654321',
+                account=self.user.email,
+            )
+        )
+        self.assertFalse(
+            UserVerificationServices.verify_reset_pwd(
+                code='654321',
+                account=self.user.email,
+            )
+        )
+
+
+class BlackListServiceTests(BaseUsersTestCase):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+        self.user = self.make_user(
+            email='blacklist@test.com',
+            full_name='Blacklist User',
+            groups=[self.member_group],
+        )
+
+    def test_set_blacklisted_access_token_persists_record(self):
+        token = AccessToken.for_user(self.user)
+
+        BlackListService.set_blacklisted(user=self.user, token=token)
+
+        black_name = f'{BlackListService.blacklist_prefix}:{token["jti"]}'
+        self.assertTrue(BlackListToken.objects.filter(token=black_name, user=self.user).exists())
+        self.assertTrue(BlackListService.is_token_blacklisted(token))
+
+    @patch('apps.users.services.services.cache.get', side_effect=RuntimeError('cache down'))
+    def test_is_token_blacklisted_falls_back_to_db(self, _mock_cache_get):
+        token = AccessToken.for_user(self.user)
+        black_name = f'{BlackListService.blacklist_prefix}:{token["jti"]}'
+        BlackListToken.objects.create(
+            token=black_name,
+            expires_at=timezone.now(),
+            user=self.user,
+        )
+
+        self.assertTrue(BlackListService.is_token_blacklisted(token))
+
+    def test_is_token_blacklisted_returns_false_without_token(self):
+        self.assertFalse(BlackListService.is_token_blacklisted(None))

--- a/apps/users/tests.py
+++ b/apps/users/tests.py
@@ -6,8 +6,11 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.core.cache import cache
 from django.test import RequestFactory, TestCase
+from django.urls import reverse
 from django.utils import timezone
+from rest_framework import status
 from rest_framework.exceptions import ValidationError
+from rest_framework.test import APITestCase
 from rest_framework_simplejwt.tokens import AccessToken
 
 from apps.users.models import BlackListToken
@@ -276,3 +279,149 @@ class BlackListServiceTests(BaseUsersTestCase):
 
     def test_is_token_blacklisted_returns_false_without_token(self):
         self.assertFalse(BlackListService.is_token_blacklisted(None))
+
+
+class UserViewsAPITests(APITestCase):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+        self.superadmin_group, _ = Group.objects.get_or_create(name='SuperAdmin')
+        self.manager_group, _ = Group.objects.get_or_create(name='EventManager')
+        self.member_group, _ = Group.objects.get_or_create(name='Member')
+
+        self.admin = User.objects.create_user(
+            email='admin-api@test.com',
+            password='AdminPass123!@#',
+            full_name='Admin API',
+        )
+        self.admin.groups.set([self.superadmin_group])
+
+        self.manager = User.objects.create_user(
+            email='manager-api@test.com',
+            password='ManagerPass123!@#',
+            full_name='Manager API',
+        )
+        self.manager.groups.set([self.manager_group])
+
+        self.member = User.objects.create_user(
+            email='member-api@test.com',
+            password='MemberPass123!@#',
+            full_name='Member API',
+            date_of_birth=date(2000, 1, 1),
+        )
+        self.member.groups.set([self.member_group])
+
+    @patch('apps.users.views.UserVerificationServices.send_verification_mail')
+    def test_verification_send_returns_accepted_for_authenticated_user(self, mock_send_mail):
+        self.client.force_authenticate(user=self.member)
+
+        response = self.client.post(
+            reverse('v1:users_app:email-verification-send'),
+            {'mode': 'verifyEmail'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        mock_send_mail.assert_called_once()
+
+    @patch(
+        'apps.users.views.UserVerificationServices.send_verification_mail',
+        side_effect=RuntimeError('Generate token error'),
+    )
+    def test_verification_send_returns_bad_request_on_service_error(self, _mock_send_mail):
+        self.client.force_authenticate(user=self.member)
+
+        response = self.client.post(
+            reverse('v1:users_app:email-verification-send'),
+            {'mode': 'verifyEmail'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['detail'], 'Generate token error')
+
+    @patch('apps.users.views.UserVerificationServices.verify_mail', return_value=1)
+    def test_verification_verify_returns_ok_for_valid_code(self, mock_verify_mail):
+        response = self.client.post(
+            reverse('v1:users_app:email-verification-verify'),
+            {'mode': 'verifyEmail', 'code': 'valid-code'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_verify_mail.assert_called_once_with(token='valid-code')
+
+    @patch('apps.users.views.UserVerificationServices.verify_mail', return_value=0)
+    def test_verification_verify_returns_bad_request_for_invalid_code(self, _mock_verify_mail):
+        response = self.client.post(
+            reverse('v1:users_app:email-verification-verify'),
+            {'mode': 'verifyEmail', 'code': 'invalid-code'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch('apps.users.views.UserVerificationServices.send_reset_pwd_mail')
+    def test_password_reset_create_returns_accepted(self, mock_send_reset):
+        response = self.client.post(
+            reverse('v1:users_app:password-reset-list'),
+            {'email': self.member.email},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(response.data['detail'], 'verification code has been sent')
+        mock_send_reset.assert_called_once_with(account=self.member.email)
+
+    @patch(
+        'apps.users.serializers.UserVerificationServices.verify_reset_pwd',
+        return_value=True,
+    )
+    def test_password_reset_verify_updates_password(self, mock_verify_reset):
+        response = self.client.post(
+            reverse('v1:users_app:password-reset-verify'),
+            {
+                'email': self.member.email,
+                'password': 'NewPass123!@#',
+                'verification_code': '654321',
+            },
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['message'], 'password reset successful')
+        self.member.refresh_from_db()
+        self.assertTrue(self.member.check_password('NewPass123!@#'))
+        mock_verify_reset.assert_called_once_with(code='654321', account=self.member.email)
+
+    def test_member_retrieve_other_user_is_forbidden(self):
+        self.client.force_authenticate(user=self.member)
+
+        response = self.client.get(
+            reverse('v1:users_app:users-detail', kwargs={'pk': self.admin.pk}),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_manager_retrieve_member_hides_date_of_birth(self):
+        self.client.force_authenticate(user=self.manager)
+
+        response = self.client.get(
+            reverse('v1:users_app:users-detail', kwargs={'pk': self.member.pk}),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['email'], self.member.email)
+        self.assertNotIn('date_of_birth', response.data)
+        self.assertNotIn('is_active', response.data)
+
+    def test_owner_retrieve_self_includes_private_fields(self):
+        self.client.force_authenticate(user=self.member)
+
+        response = self.client.get(
+            reverse('v1:users_app:users-detail', kwargs={'pk': self.member.pk}),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['email'], self.member.email)
+        self.assertIn('date_of_birth', response.data)


### PR DESCRIPTION
- Add Django tests for UserRegistrationSerializer and UserProfileSerializer
- Add service tests for verification mail, reset password flow, and blacklist handling
- Add API tests for verification, password reset, and user detail permission/field visibility

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add end-to-end tests for the users module: serializers (`UserRegistrationSerializer`, `UserProfileSerializer`), services (verification mail, reset password, blacklist), and API views for email verification, password reset, and user detail retrieval. Tests cover role-based field visibility, age/password validation, token caching and consumption, blacklist DB fallback, permissions, and expected status codes.

<sup>Written for commit 1c964c3f166da282c3443730b433495635de309d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for user-related functionality, including serializer validation, authentication flows, and API endpoint permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->