### PR TITLE
Feat/events teams test coverage

### DIFF
--- a/apps/events/models.py
+++ b/apps/events/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime, time
+from datetime import time, timedelta
 
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
@@ -38,7 +38,7 @@ class Event(SoftDeleteModel):
         if self.start_time and self.end_time:
             midnight = time(0, 0)
             is_midnight = self.start_time.time() == midnight and self.end_time.time() == midnight
-            is_oneday_diff = (self.end_time - self.start_time) == datetime.timedelta(days=1)
+            is_oneday_diff = (self.end_time - self.start_time) == timedelta(days=1)
             return bool(is_midnight and is_oneday_diff)
         return False
 

--- a/apps/events/serializers.py
+++ b/apps/events/serializers.py
@@ -182,7 +182,8 @@ class EventSerializer(serializers.ModelSerializer):
         if instance.location:
             ret['location_name'] = instance.location.name
 
-        ret['rule_config'] = instance.match_config.rule_config
+        match_config = getattr(instance, 'match_config', None)
+        ret['rule_config'] = match_config.rule_config if match_config else None
 
         return ret
 

--- a/apps/events/tests.py
+++ b/apps/events/tests.py
@@ -1,12 +1,29 @@
+import logging
+from contextlib import contextmanager
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from .models import EventMatchTemplate
+from apps.teams.models import Team
+
+from .models import Event, EventMatchTemplate, EventTeam, EventTeamMember
 
 User = get_user_model()
+
+
+@contextmanager
+def suppress_django_request_warnings():
+    logger = logging.getLogger('django.request')
+    old_level = logger.level
+    logger.setLevel(logging.ERROR)
+    try:
+        yield
+    finally:
+        logger.setLevel(old_level)
 
 
 class MatchTemplateAPITests(APITestCase):
@@ -55,7 +72,8 @@ class MatchTemplateAPITests(APITestCase):
     def test_create_template_as_regular_user_forbidden(self):
         self.client.force_authenticate(user=self.regular_user)
         data = {'name': 'Regular Template', 'items': []}
-        response = self.client.post(self.template_url, data, format='json')
+        with suppress_django_request_warnings():
+            response = self.client.post(self.template_url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_list_templates_authenticated(self):
@@ -69,3 +87,110 @@ class MatchTemplateAPITests(APITestCase):
             self.assertEqual(response.data['count'], initial_count + 1)
         else:
             self.assertEqual(len(response.data), initial_count + 1)
+
+
+class EventAndEventTeamAPITests(APITestCase):
+    def setUp(self):
+        self.admin_group, _ = Group.objects.get_or_create(name='SuperAdmin')
+        self.manager_group, _ = Group.objects.get_or_create(name='EventManager')
+        self.member_group, _ = Group.objects.get_or_create(name='Member')
+
+        self.admin = User.objects.create_user(
+            email='events-admin@test.com',
+            password='AdminPass123!@#',
+            full_name='Events Admin',
+        )
+        self.admin.groups.set([self.admin_group])
+
+        self.manager = User.objects.create_user(
+            email='events-manager@test.com',
+            password='ManagerPass123!@#',
+            full_name='Events Manager',
+        )
+        self.manager.groups.set([self.manager_group])
+
+        self.member = User.objects.create_user(
+            email='events-member@test.com',
+            password='MemberPass123!@#',
+            full_name='Events Member',
+        )
+        self.member.groups.set([self.member_group])
+
+        self.events_url = reverse('v1:events_app:events-list')
+        self.event_teams_me_url = reverse('v1:events_app:event-teams-me')
+
+    def test_event_calendar_query_filters_by_time_range(self):
+        now = timezone.now()
+        in_range = Event.objects.create(
+            name='In Range',
+            type=Event.TypeChoices.LEAGUE,
+            start_time=now,
+            end_time=now + timezone.timedelta(hours=2),
+        )
+        Event.objects.create(
+            name='Out Of Range',
+            type=Event.TypeChoices.LEAGUE,
+            start_time=now + timezone.timedelta(days=5),
+            end_time=now + timezone.timedelta(days=5, hours=2),
+        )
+
+        self.client.force_authenticate(user=self.member)
+        response = self.client.get(
+            self.events_url,
+            {
+                'calendar': 'true',
+                'start': (now - timezone.timedelta(hours=1)).isoformat(),
+                'end': (now + timezone.timedelta(hours=3)).isoformat(),
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], in_range.id)
+        self.assertEqual(response.data[0]['title'], in_range.name)
+
+    def test_manager_can_create_event_team_with_new_team_name(self):
+        event = Event.objects.create(name='League 2026', type=Event.TypeChoices.LEAGUE)
+        self.client.force_authenticate(user=self.manager)
+
+        response = self.client.post(
+            reverse('v1:events_app:event-teams-nested-list', kwargs={'event_id': event.id}),
+            {'new_team_name': 'Fresh Team'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        event_team = EventTeam.objects.get(pk=response.data['id'])
+        self.assertEqual(event_team.event, event)
+        self.assertEqual(event_team.team.name, 'Fresh Team')
+        self.assertEqual(event_team.team.creator, self.manager)
+
+    def test_member_cannot_create_event_team(self):
+        event = Event.objects.create(name='Members League', type=Event.TypeChoices.LEAGUE)
+        self.client.force_authenticate(user=self.member)
+
+        with suppress_django_request_warnings():
+            response = self.client.post(
+                reverse('v1:events_app:event-teams-nested-list', kwargs={'event_id': event.id}),
+                {'new_team_name': 'Should Fail'},
+                format='json',
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_event_teams_me_returns_only_joined_teams(self):
+        event = Event.objects.create(name='Joined Event', type=Event.TypeChoices.LEAGUE)
+        joined_team = Team.objects.create(name='Joined Team', creator=self.manager)
+        other_team = Team.objects.create(name='Other Team', creator=self.manager)
+
+        joined_event_team = EventTeam.objects.create(event=event, team=joined_team)
+        EventTeam.objects.create(event=event, team=other_team)
+
+        EventTeamMember.objects.create(event_team=joined_event_team, user=self.member)
+
+        self.client.force_authenticate(user=self.member)
+        response = self.client.get(self.event_teams_me_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['team_name'], 'Joined Team')

--- a/apps/events/tests_serializers.py
+++ b/apps/events/tests_serializers.py
@@ -73,6 +73,15 @@ class TestEventSerializer(APITestCase):
         data = {
             'name': 'New Tournament',
             'type': 'TN',
+            'rule_config': {
+                'winning_sets': 3,
+                'set_winning_points': 11,
+                'use_deuce': True,
+                'team_winning_points': 3,
+                'play_all_sets': False,
+                'play_all_matches': False,
+                'count_points_by_sets': False,
+            },
             'lunch_options': [
                 {'name': 'Standard', 'price': 80},
                 {'name': 'Vegetarian', 'price': 100},
@@ -93,6 +102,15 @@ class TestEventSerializer(APITestCase):
 
         data = {
             'name': 'Updated Event',
+            'rule_config': {
+                'winning_sets': 3,
+                'set_winning_points': 11,
+                'use_deuce': True,
+                'team_winning_points': 3,
+                'play_all_sets': False,
+                'play_all_matches': False,
+                'count_points_by_sets': False,
+            },
             'lunch_options': [
                 {'name': 'New Option 1', 'price': 90},
                 {'name': 'New Option 2', 'price': 110},

--- a/apps/teams/tests.py
+++ b/apps/teams/tests.py
@@ -1,1 +1,105 @@
-# Create your tests here.
+import logging
+from contextlib import contextmanager
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.teams.models import Team
+
+User = get_user_model()
+
+
+@contextmanager
+def suppress_django_request_warnings():
+    logger = logging.getLogger('django.request')
+    old_level = logger.level
+    logger.setLevel(logging.ERROR)
+    try:
+        yield
+    finally:
+        logger.setLevel(old_level)
+
+
+class TeamAPITests(APITestCase):
+    def setUp(self):
+        self.admin_group, _ = Group.objects.get_or_create(name='SuperAdmin')
+        self.manager_group, _ = Group.objects.get_or_create(name='EventManager')
+        self.member_group, _ = Group.objects.get_or_create(name='Member')
+
+        self.admin = User.objects.create_user(
+            email='teams-admin@test.com',
+            password='AdminPass123!@#',
+            full_name='Teams Admin',
+        )
+        self.admin.groups.set([self.admin_group])
+
+        self.manager = User.objects.create_user(
+            email='teams-manager@test.com',
+            password='ManagerPass123!@#',
+            full_name='Teams Manager',
+        )
+        self.manager.groups.set([self.manager_group])
+
+        self.member = User.objects.create_user(
+            email='teams-member@test.com',
+            password='MemberPass123!@#',
+            full_name='Teams Member',
+        )
+        self.member.groups.set([self.member_group])
+
+        self.list_url = reverse('v1:teams_app:teams-list')
+
+    def test_manager_can_create_team(self):
+        self.client.force_authenticate(user=self.manager)
+
+        response = self.client.post(
+            self.list_url,
+            {'name': 'Manager Team'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        team = Team.objects.get(pk=response.data['id'])
+        self.assertEqual(team.name, 'Manager Team')
+        self.assertEqual(team.creator, self.manager)
+
+    def test_member_cannot_create_team(self):
+        self.client.force_authenticate(user=self.member)
+
+        with suppress_django_request_warnings():
+            response = self.client.post(
+                self.list_url,
+                {'name': 'Forbidden Team'},
+                format='json',
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_manager_can_update_team_name(self):
+        team = Team.objects.create(name='Original Name', creator=self.manager)
+        self.client.force_authenticate(user=self.manager)
+
+        response = self.client.patch(
+            reverse('v1:teams_app:teams-detail', kwargs={'id': team.pk}),
+            {'name': 'Updated Name'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        team.refresh_from_db()
+        self.assertEqual(team.name, 'Updated Name')
+
+    def test_admin_can_soft_delete_team(self):
+        team = Team.objects.create(name='Delete Me', creator=self.manager)
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.delete(
+            reverse('v1:teams_app:teams-detail', kwargs={'id': team.pk}),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        team.refresh_from_db()
+        self.assertIsNotNone(team.deleted_at)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds API test coverage for events and teams, covering calendar filtering, permissions, nested event team creation, and member “me” listings. Also fixes serializer and model edge cases to prevent crashes and ensure correct all-day detection.

- **Bug Fixes**
  - Event serializer: safely handle missing `match_config` and return `rule_config = null` instead of raising.
  - Event model: use `timedelta(days=1)` in `all_day` check for accurate one-day detection.

<sup>Written for commit b67edadfaf966b27518eb0fbef82029967ed3991. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event team creation and management functionality with role-based access control
  * Enhanced event calendar with date range filtering capabilities
  * Team management with create, update, and soft-delete operations
  * Support for rule configuration in events

* **Bug Fixes**
  * Improved event serializer robustness when configuration data is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->