### PR TITLE
Feat/matches test coverage

### DIFF
--- a/apps/matches/tests.py
+++ b/apps/matches/tests.py
@@ -1,5 +1,9 @@
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.test import TestCase
+from rest_framework.exceptions import ValidationError as DRFValidationError
 
 from apps.events.models import (
     Event,
@@ -7,10 +11,13 @@ from apps.events.models import (
     EventMatchTemplate,
     EventMatchTemplateItem,
     EventTeam,
+    EventTeamMember,
 )
 from apps.matches.models import (
     BaseMatch,
+    PlayerMatchParticipant,
 )
+from apps.matches.serializers import TeamMatchSerializer
 from apps.matches.services import MatchService
 from apps.teams.models import Team
 
@@ -270,3 +277,189 @@ class MatchScoringTests(TestCase):
         pm.refresh_from_db()
         self.assertEqual(pm.status, BaseMatch.StatusChoices.COMPLETED)
         self.assertEqual(pm.winner, BaseMatch.WinnerChoices.TEAM_A)
+
+
+class MatchServiceAndSerializerTests(TestCase):
+    def setUp(self):
+        self.manager = User.objects.create_user(
+            email='matches@example.com',
+            full_name='Matches User',
+            password='password',
+        )
+        self.event = Event.objects.create(name='Service Event')
+        self.other_event = Event.objects.create(name='Other Service Event')
+
+        team_a_base = Team.objects.create(name='Service Team A', creator=self.manager)
+        team_b_base = Team.objects.create(name='Service Team B', creator=self.manager)
+        team_c_base = Team.objects.create(name='Service Team C', creator=self.manager)
+
+        self.team_a = EventTeam.objects.create(event=self.event, team=team_a_base)
+        self.team_b = EventTeam.objects.create(event=self.event, team=team_b_base)
+        self.other_event_team = EventTeam.objects.create(event=self.other_event, team=team_c_base)
+
+        self.template = EventMatchTemplate.objects.create(
+            name='Service Template',
+            creator=self.manager,
+        )
+        EventMatchTemplateItem.objects.create(template=self.template, number=1, format='S')
+        EventMatchTemplateItem.objects.create(template=self.template, number=2, format='D')
+
+        self.config = EventMatchConfiguration.objects.create(
+            event=self.event,
+            template=self.template,
+            winning_sets=3,
+            team_winning_points=2,
+        )
+
+        self.team_match = MatchService.initialize_team_match(self.team_a, self.team_b, 1)
+        self.player_match = self.team_match.player_matches.get(number=1)
+
+        self.player_a = User.objects.create_user(
+            email='player-a@example.com',
+            full_name='Player A',
+            password='password',
+        )
+        self.player_b = User.objects.create_user(
+            email='player-b@example.com',
+            full_name='Player B',
+            password='password',
+        )
+        self.player_outsider = User.objects.create_user(
+            email='outsider@example.com',
+            full_name='Outsider',
+            password='password',
+        )
+
+        EventTeamMember.objects.create(event_team=self.team_a, user=self.player_a, is_player=True)
+        EventTeamMember.objects.create(event_team=self.team_b, user=self.player_b, is_player=True)
+        EventTeamMember.objects.create(
+            event_team=self.other_event_team,
+            user=self.player_outsider,
+            is_player=True,
+        )
+
+    def test_initialize_team_match_rejects_cross_event_teams(self):
+        with self.assertRaisesMessage(ValueError, 'Both teams must belong to the same event.'):
+            MatchService.initialize_team_match(self.team_a, self.other_event_team, 2)
+
+    def test_initialize_team_match_requires_event_match_config(self):
+        event_without_config = Event.objects.create(name='No Config Event')
+        team_x = EventTeam.objects.create(
+            event=event_without_config,
+            team=Team.objects.create(name='No Config A', creator=self.manager),
+        )
+        team_y = EventTeam.objects.create(
+            event=event_without_config,
+            team=Team.objects.create(name='No Config B', creator=self.manager),
+        )
+
+        with self.assertRaisesMessage(ValueError, 'No match configuration found for event'):
+            MatchService.initialize_team_match(team_x, team_y, 1)
+
+    def test_initialize_team_match_rejects_duplicate_match_number(self):
+        with self.assertRaises(ValidationError):
+            MatchService.initialize_team_match(self.team_a, self.team_b, 1)
+
+    def test_assign_player_to_match_sets_side_from_event_team_membership(self):
+        participant = MatchService.assign_player_to_match(
+            player_match=self.player_match,
+            player=self.player_a,
+            position=1,
+        )
+
+        self.assertEqual(participant.side, PlayerMatchParticipant.SideChoices.SIDE_A)
+        self.assertEqual(participant.player, self.player_a)
+
+    def test_assign_player_to_match_rejects_player_not_registered_in_event(self):
+        stranger = User.objects.create_user(
+            email='stranger@example.com',
+            full_name='Stranger',
+            password='password',
+        )
+
+        with self.assertRaisesMessage(ValueError, 'is not registered in this event'):
+            MatchService.assign_player_to_match(
+                player_match=self.player_match,
+                player=stranger,
+                position=1,
+            )
+
+    def test_assign_player_to_match_rejects_player_from_other_event(self):
+        with self.assertRaisesMessage(ValueError, 'is not registered in this event'):
+            MatchService.assign_player_to_match(
+                player_match=self.player_match,
+                player=self.player_outsider,
+                position=1,
+            )
+
+    def test_assign_player_to_match_requires_guest_name_for_guest(self):
+        with self.assertRaisesMessage(ValueError, 'Either player or guest_name must be provided.'):
+            MatchService.assign_player_to_match(
+                player_match=self.player_match,
+                side='A',
+                position=1,
+            )
+
+    def test_assign_player_to_match_requires_side_for_guest(self):
+        with self.assertRaisesMessage(ValueError, 'Side must be provided for guest players.'):
+            MatchService.assign_player_to_match(
+                player_match=self.player_match,
+                guest_name='Guest Player',
+                position=1,
+            )
+
+    @patch('apps.matches.serializers.MatchService.create_team_match_full')
+    def test_team_match_serializer_maps_side_a_and_side_b_participants(
+        self, mock_create_team_match
+    ):
+        serializer = TeamMatchSerializer(
+            data={
+                'team_a': self.team_a.id,
+                'team_b': self.team_b.id,
+                'number': 3,
+                'player_matches': [
+                    {
+                        'number': 1,
+                        'side_a': [{'player': self.player_a.id, 'position': 1}],
+                        'side_b': [{'player': self.player_b.id, 'position': 2}],
+                    }
+                ],
+            }
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        serializer.save()
+
+        mock_create_team_match.assert_called_once_with(
+            team_a=self.team_a,
+            team_b=self.team_b,
+            match_number=3,
+            player_matches_data=[
+                {
+                    'number': 1,
+                    'participants': [
+                        {'player': self.player_a.id, 'position': 1, 'side': 'A'},
+                        {'player': self.player_b.id, 'position': 2, 'side': 'B'},
+                    ],
+                }
+            ],
+        )
+
+    @patch('apps.matches.serializers.MatchService.create_team_match_full')
+    def test_team_match_serializer_converts_service_errors_to_validation_errors(
+        self, mock_create_team_match
+    ):
+        mock_create_team_match.side_effect = ValueError('invalid matchup')
+
+        serializer = TeamMatchSerializer(
+            data={
+                'team_a': self.team_a.id,
+                'team_b': self.team_b.id,
+                'number': 4,
+                'player_matches': [],
+            }
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        with self.assertRaisesMessage(DRFValidationError, 'invalid matchup'):
+            serializer.save()

--- a/apps/matches/tests.py
+++ b/apps/matches/tests.py
@@ -41,12 +41,10 @@ class MatchScoringTests(TestCase):
         self.config = EventMatchConfiguration.objects.create(
             event=self.event,
             template=self.template,
-            rule_config={
-                'winning_sets': 3,
-                'team_winning_points': 3,
-                'play_all_sets': False,
-                'play_all_matches': False,
-            },
+            winning_sets=3,
+            team_winning_points=3,
+            play_all_sets=False,
+            play_all_matches=False,
         )
 
         # Initialize a Team Match
@@ -76,7 +74,7 @@ class MatchScoringTests(TestCase):
     def test_player_match_play_all(self):
         """Test PlayerMatch waits for all sets (Play All mode)"""
         # Update config to play_all_sets = True
-        self.config.rule_config['play_all_sets'] = True
+        self.config.play_all_sets = True
         self.config.save()
 
         pm = self.player_matches[0]
@@ -117,7 +115,7 @@ class MatchScoringTests(TestCase):
 
     def test_team_match_play_all(self):
         """Test TeamMatch waits for all matches (Play All mode)"""
-        self.config.rule_config['play_all_matches'] = True
+        self.config.play_all_matches = True
         self.config.save()
 
         # A wins 3 matches (would be win in race mode)
@@ -195,8 +193,8 @@ class MatchScoringTests(TestCase):
         Match 2: B wins 3-1 (1 set for A, 3 for B)
         Total should be 4:5
         """
-        self.config.rule_config['count_points_by_sets'] = True
-        self.config.rule_config['play_all_matches'] = True
+        self.config.count_points_by_sets = True
+        self.config.play_all_matches = True
         self.config.save()
 
         # Match 1: A wins 3-2 (A:3, B:2)
@@ -240,9 +238,9 @@ class MatchScoringTests(TestCase):
 
     def test_player_match_deuce(self):
         """Test deuce logic: must win by 2 points when use_deuce is True"""
-        self.config.rule_config['use_deuce'] = True
-        self.config.rule_config['set_winning_points'] = 11
-        self.config.rule_config['winning_sets'] = 1
+        self.config.use_deuce = True
+        self.config.set_winning_points = 11
+        self.config.winning_sets = 1
         self.config.save()
 
         pm = self.player_matches[0]
@@ -260,9 +258,9 @@ class MatchScoringTests(TestCase):
 
     def test_player_match_no_deuce(self):
         """Test no-deuce logic: ends exactly at target score"""
-        self.config.rule_config['use_deuce'] = False
-        self.config.rule_config['set_winning_points'] = 11
-        self.config.rule_config['winning_sets'] = 1
+        self.config.use_deuce = False
+        self.config.set_winning_points = 11
+        self.config.winning_sets = 1
         self.config.save()
 
         pm = self.player_matches[0]

--- a/apps/matches/tests_api.py
+++ b/apps/matches/tests_api.py
@@ -1,3 +1,6 @@
+import logging
+from contextlib import contextmanager
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.urls import reverse
@@ -11,10 +14,24 @@ from apps.teams.models import Team
 User = get_user_model()
 
 
+@contextmanager
+def suppress_django_request_warnings():
+    logger = logging.getLogger('django.request')
+    old_level = logger.level
+    logger.setLevel(logging.ERROR)
+    try:
+        yield
+    finally:
+        logger.setLevel(old_level)
+
+
 class TeamMatchAPITests(APITestCase):
     def setUp(self):
         self.user = User.objects.create_user(
-            email='test@example.com', password='password', full_name='Test User'
+            email='manager@example.com', password='password', full_name='Manager User'
+        )
+        self.member = User.objects.create_user(
+            email='member@example.com', password='password', full_name='Member User'
         )
         self.manager_group, _ = Group.objects.get_or_create(name='EventManager')
         self.user.groups.add(self.manager_group)
@@ -27,16 +44,29 @@ class TeamMatchAPITests(APITestCase):
 
         self.team_a = EventTeam.objects.create(event=self.event, team=self.team_a_base)
         self.team_b = EventTeam.objects.create(event=self.event, team=self.team_b_base)
+        self.team_c_base = Team.objects.create(name='Team C', creator=self.user)
+        self.team_c = EventTeam.objects.create(event=self.event, team=self.team_c_base)
+
+        self.other_event = Event.objects.create(name='Other Event')
+        self.other_team_base = Team.objects.create(name='Other Team', creator=self.user)
+        self.other_event_team = EventTeam.objects.create(
+            event=self.other_event, team=self.other_team_base
+        )
 
         # Setup Match Template and Config
         self.template = EventMatchTemplate.objects.create(
             name='Standard Template', creator=self.user
         )
         self.config = EventMatchConfiguration.objects.create(
-            event=self.event, template=self.template, rule_config={'team_winning_points': 3}
+            event=self.event,
+            template=self.template,
+            team_winning_points=3,
         )
 
         self.list_url = reverse('v1:matches_app:team-matches-list')
+        self.nested_list_url = reverse(
+            'v1:events_app:team-matches-nested-list', kwargs={'event_team_id': self.team_a.id}
+        )
 
     def test_list_team_matches(self):
         TeamMatch.objects.create(team_a=self.team_a, team_b=self.team_b, number=1)
@@ -60,3 +90,84 @@ class TeamMatchAPITests(APITestCase):
         response = self.client.post(self.list_url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(TeamMatch.objects.filter(number=2).count(), 1)
+
+    def test_nested_list_filters_by_event_team(self):
+        included = TeamMatch.objects.create(team_a=self.team_a, team_b=self.team_b, number=1)
+        TeamMatch.objects.create(team_a=self.team_b, team_b=self.team_c, number=2)
+
+        response = self.client.get(self.nested_list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data['results'] if 'results' in response.data else response.data
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['id'], included.id)
+
+    def test_member_cannot_create_team_match(self):
+        self.client.force_authenticate(user=self.member)
+        with suppress_django_request_warnings():
+            response = self.client.post(
+                self.list_url,
+                {
+                    'team_a': self.team_a.id,
+                    'team_b': self.team_b.id,
+                    'number': 5,
+                    'player_matches': [],
+                },
+                format='json',
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_manager_can_update_team_match_number(self):
+        team_match = TeamMatch.objects.create(team_a=self.team_a, team_b=self.team_b, number=1)
+
+        response = self.client.patch(
+            reverse('v1:matches_app:team-matches-detail', kwargs={'pk': team_match.pk}),
+            {'number': 9},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        team_match.refresh_from_db()
+        self.assertEqual(team_match.number, 9)
+
+    def test_manager_can_delete_team_match(self):
+        team_match = TeamMatch.objects.create(team_a=self.team_a, team_b=self.team_b, number=1)
+
+        response = self.client.delete(
+            reverse('v1:matches_app:team-matches-detail', kwargs={'pk': team_match.pk}),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        team_match.refresh_from_db()
+        self.assertIsNotNone(team_match.deleted_at)
+
+    def test_create_team_match_rejects_cross_event_matchup(self):
+        with suppress_django_request_warnings():
+            response = self.client.post(
+                self.list_url,
+                {
+                    'team_a': self.team_a.id,
+                    'team_b': self.other_event_team.id,
+                    'number': 6,
+                    'player_matches': [],
+                },
+                format='json',
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_team_match_rejects_same_team_matchup(self):
+        with suppress_django_request_warnings():
+            response = self.client.post(
+                self.list_url,
+                {
+                    'team_a': self.team_a.id,
+                    'team_b': self.team_a.id,
+                    'number': 7,
+                    'player_matches': [],
+                },
+                format='json',
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expand matches test coverage and align tests with the new event config fields (replace `rule_config` with explicit fields like `winning_sets`, `play_all_sets`, `play_all_matches`, etc.).
Coverage now includes player/team win conditions, deuce vs no‑deuce, set-based scoring, participant assignment validation, serializer side mapping and ValueError→DRF validation errors, plus API permissions, nested listing, and cross‑event/same‑team matchup validation.

<sup>Written for commit 6b06652153b0e5eba48d541e5b0079ec33a06433. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test suite for match service initialization, including validation of team event membership, duplicate match detection, and player assignment scenarios.
  * Enhanced API endpoint testing with improved test fixtures and new validation cases for permission enforcement and match creation constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->