### PR TITLE
Feat/bruno cross module flow

### DIFF
--- a/nexus_integration_test/24.createTeam.yml
+++ b/nexus_integration_test/24.createTeam.yml
@@ -1,0 +1,49 @@
+info:
+  name: 24.createTeam
+  type: http
+  seq: 26
+
+http:
+  method: POST
+  url: 127.0.0.1:8000/api/v1/teams/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+  body:
+    type: json
+    data: |-
+      {
+        "name": "Bruno Integration Team"
+      }
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',
+          {
+            email: 'testEventManager@test.com',
+            password: 'testEventManager'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const data = res.getBody();
+        bru.setVar("team_id", data.id);
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "201"
+    - expression: res.body.id
+      operator: isNumber
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/25.createMatchTemplate.yml
+++ b/nexus_integration_test/25.createMatchTemplate.yml
@@ -1,0 +1,56 @@
+info:
+  name: 25.createMatchTemplate
+  type: http
+  seq: 27
+
+http:
+  method: POST
+  url: 127.0.0.1:8000/api/v1/match-templates/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+  body:
+    type: json
+    data: |-
+      {
+        "name": "Bruno Integration Template",
+        "items": [
+          {
+            "number": 1,
+            "format": "S",
+            "requirement": "Open Singles"
+          }
+        ]
+      }
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',
+          {
+            email: 'testEventManager@test.com',
+            password: 'testEventManager'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const data = res.getBody();
+        bru.setVar("template_id", data.id);
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "201"
+    - expression: res.body.id
+      operator: isNumber
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/26.createEvent.yml
+++ b/nexus_integration_test/26.createEvent.yml
@@ -1,0 +1,63 @@
+info:
+  name: 26.createEvent
+  type: http
+  seq: 28
+
+http:
+  method: POST
+  url: 127.0.0.1:8000/api/v1/events/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+  body:
+    type: json
+    data: |-
+      {
+        "name": "Bruno Integration Event",
+        "type": "LG",
+        "location_name": "Bruno Test Court",
+        "rule_config": {
+          "winning_sets": 3,
+          "set_winning_points": 11,
+          "use_deuce": true,
+          "team_winning_points": 3,
+          "play_all_sets": false,
+          "play_all_matches": false,
+          "count_points_by_sets": false
+        }
+      }
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',
+          {
+            email: 'testEventManager@test.com',
+            password: 'testEventManager'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const data = res.getBody();
+        bru.setVar("event_id", data.id);
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "201"
+    - expression: res.body.id
+      operator: isNumber
+    - expression: res.body.location_name
+      operator: eq
+      value: Bruno Test Court
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/27.registerEventTeam.yml
+++ b/nexus_integration_test/27.registerEventTeam.yml
@@ -1,0 +1,55 @@
+info:
+  name: 27.registerEventTeam
+  type: http
+  seq: 29
+
+http:
+  method: POST
+  url: 127.0.0.1:8000/api/v1/events/{{event_id}}/event-teams/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+  body:
+    type: json
+    data: |-
+      {
+        "team": {{team_id}}
+      }
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',
+          {
+            email: 'testEventManager@test.com',
+            password: 'testEventManager'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const data = res.getBody();
+        const teamId = Number(bru.getVar("team_id"));
+
+        if (data.team !== teamId) {
+          throw new Error(`Expected team ${teamId}, got ${data.team}`);
+        }
+
+        bru.setVar("event_team_id", data.id);
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "201"
+    - expression: res.body.id
+      operator: isNumber
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/28.addManagerToEventTeam.yml
+++ b/nexus_integration_test/28.addManagerToEventTeam.yml
@@ -1,0 +1,55 @@
+info:
+  name: 28.addManagerToEventTeam
+  type: http
+  seq: 30
+
+http:
+  method: POST
+  url: 127.0.0.1:8000/api/v1/event-teams/{{event_team_id}}/members/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+  body:
+    type: json
+    data: |-
+      {
+        "is_player": true
+      }
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',
+          {
+            email: 'testEventManager@test.com',
+            password: 'testEventManager'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const data = res.getBody();
+        const eventTeamId = Number(bru.getVar("event_team_id"));
+
+        if (data.event_team !== eventTeamId) {
+          throw new Error(`Expected event_team ${eventTeamId}, got ${data.event_team}`);
+        }
+        if (data.is_player !== true) {
+          throw new Error('Expected is_player to be true');
+        }
+
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "201"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/29.getMyEventTeams.yml
+++ b/nexus_integration_test/29.getMyEventTeams.yml
@@ -1,0 +1,48 @@
+info:
+  name: 29.getMyEventTeams
+  type: http
+  seq: 31
+
+http:
+  method: GET
+  url: 127.0.0.1:8000/api/v1/event-teams/me/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',
+          {
+            email: 'testEventManager@test.com',
+            password: 'testEventManager'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const data = res.getBody();
+        const eventTeams = data.results || data;
+        const eventTeamId = Number(bru.getVar("event_team_id"));
+        const target = eventTeams.find((item) => item.id === eventTeamId);
+
+        if (!target) {
+          throw new Error(`Joined event team ${eventTeamId} not found in /event-teams/me/`);
+        }
+
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "200"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/30.cleanupIntegrationResources.yml
+++ b/nexus_integration_test/30.cleanupIntegrationResources.yml
@@ -1,0 +1,67 @@
+info:
+  name: 30.cleanupIntegrationResources
+  type: http
+  seq: 32
+
+http:
+  method: DELETE
+  url: 127.0.0.1:8000/api/v1/event-teams/{{event_team_id}}/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',
+          {
+            email: 'testEventManager@test.com',
+            password: 'testEventManager'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const axios = require('axios');
+        const token = bru.getVar("jwt_access");
+        const eventId = bru.getVar("event_id");
+        const teamId = bru.getVar("team_id");
+        const templateId = bru.getVar("template_id");
+
+        const headers = {
+          Authorization: `Bearer ${token}`
+        };
+
+        if (eventId) {
+          await axios.delete(`http://127.0.0.1:8000/api/v1/events/${eventId}/`, { headers });
+        }
+
+        if (teamId) {
+          await axios.delete(`http://127.0.0.1:8000/api/v1/teams/${teamId}/`, { headers });
+        }
+
+        if (templateId) {
+          await axios.delete(`http://127.0.0.1:8000/api/v1/match-templates/${templateId}/`, {
+            headers
+          });
+        }
+
+        bru.setVar("event_team_id", null);
+        bru.setVar("event_id", null);
+        bru.setVar("team_id", null);
+        bru.setVar("template_id", null);
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "204"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/30.createLunchOption.yml
+++ b/nexus_integration_test/30.createLunchOption.yml
@@ -1,0 +1,54 @@
+info:
+  name: 30.createLunchOption
+  type: http
+  seq: 32
+
+http:
+  method: POST
+  url: 127.0.0.1:8000/api/v1/events/{{event_id}}/lunch-options/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+  body:
+    type: json
+    data: |-
+      {
+        "name": "Bruno Bento",
+        "price": 120
+      }
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',
+          {
+            email: 'testEventManager@test.com',
+            password: 'testEventManager'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const data = res.getBody();
+
+        bru.setVar("lunch_option_id", data.id);
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "201"
+    - expression: res.body.id
+      operator: isNumber
+    - expression: res.body.name
+      operator: eq
+      value: Bruno Bento
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/31.getEventLunchOptions.yml
+++ b/nexus_integration_test/31.getEventLunchOptions.yml
@@ -1,0 +1,51 @@
+info:
+  name: 31.getEventLunchOptions
+  type: http
+  seq: 33
+
+http:
+  method: GET
+  url: 127.0.0.1:8000/api/v1/events/{{event_id}}/lunch-options/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',
+          {
+            email: 'testEventManager@test.com',
+            password: 'testEventManager'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const data = res.getBody();
+        const results = data.results || data;
+        const lunchOptionId = Number(bru.getVar("lunch_option_id"));
+        const target = results.find((item) => item.id === lunchOptionId);
+
+        if (!target) {
+          throw new Error(`Lunch option ${lunchOptionId} not found in event lunch options.`);
+        }
+        if (target.name !== 'Bruno Bento') {
+          throw new Error(`Expected lunch option name Bruno Bento, got ${target.name}`);
+        }
+
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "200"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/32.getMyEventTeamMembers.yml
+++ b/nexus_integration_test/32.getMyEventTeamMembers.yml
@@ -1,0 +1,55 @@
+info:
+  name: 32.getMyEventTeamMembers
+  type: http
+  seq: 34
+
+http:
+  method: GET
+  url: 127.0.0.1:8000/api/v1/event-teams/{{event_team_id}}/members/?user=me
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',
+          {
+            email: 'testEventManager@test.com',
+            password: 'testEventManager'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const data = res.getBody();
+        const results = data.results || data;
+
+        if (!Array.isArray(results) || results.length === 0) {
+          throw new Error('Expected at least one event team member for user=me.');
+        }
+
+        const target = results.find((item) => item.event_team === Number(bru.getVar("event_team_id")));
+
+        if (!target) {
+          throw new Error('Current user membership was not found in event team member list.');
+        }
+        if (target.is_player !== true) {
+          throw new Error('Expected current user membership to be a player.');
+        }
+
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "200"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/33.cleanupIntegrationResources.yml
+++ b/nexus_integration_test/33.cleanupIntegrationResources.yml
@@ -1,7 +1,7 @@
 info:
-  name: 30.cleanupIntegrationResources
+  name: 33.cleanupIntegrationResources
   type: http
-  seq: 32
+  seq: 35
 
 http:
   method: DELETE
@@ -54,6 +54,7 @@ runtime:
         bru.setVar("event_id", null);
         bru.setVar("team_id", null);
         bru.setVar("template_id", null);
+        bru.setVar("lunch_option_id", null);
         bru.setVar("jwt_access", null);
   assertions:
     - expression: res.status


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a cross‑module integration flow with Bruno to cover the event manager journey end‑to‑end across teams, match templates, events, memberships, and lunch options. Verifies critical paths and cleans up created resources.

- **New Features**
  - Adds 10 chained Bruno tests (24–33) that log in via `before-request`, pass JWTs, and share IDs through vars.
  - Covers: create team, create match template, create event, register team to event, add manager as a player, fetch “my” event teams, create and list lunch options, fetch “my” event team members, and final cleanup.
  - Includes assertions for status codes and key fields (IDs, names, relationships) to confirm correct linking between modules.
  - Cleanup step deletes the event team, event, team, and template to keep the environment clean.

<sup>Written for commit 2fafa61d7a17ef3e0c8bbe53638437a74532df6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration test suite covering complete event management workflows, including team and event creation, team registration, member management, lunch option handling, and automated resource cleanup with authentication and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->