### PR TITLE
Extend Bruno event integration flow

### DIFF
--- a/nexus_integration_test/30.createLunchOption.yml
+++ b/nexus_integration_test/30.createLunchOption.yml
@@ -1,0 +1,54 @@
+info:
+  name: 30.createLunchOption
+  type: http
+  seq: 32
+
+http:
+  method: POST
+  url: 127.0.0.1:8000/api/v1/events/{{event_id}}/lunch-options/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+  body:
+    type: json
+    data: |-
+      {
+        "name": "Bruno Bento",
+        "price": 120
+      }
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',
+          {
+            email: 'testEventManager@test.com',
+            password: 'testEventManager'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const data = res.getBody();
+
+        bru.setVar("lunch_option_id", data.id);
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "201"
+    - expression: res.body.id
+      operator: isNumber
+    - expression: res.body.name
+      operator: eq
+      value: Bruno Bento
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/31.getEventLunchOptions.yml
+++ b/nexus_integration_test/31.getEventLunchOptions.yml
@@ -1,0 +1,51 @@
+info:
+  name: 31.getEventLunchOptions
+  type: http
+  seq: 33
+
+http:
+  method: GET
+  url: 127.0.0.1:8000/api/v1/events/{{event_id}}/lunch-options/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',
+          {
+            email: 'testEventManager@test.com',
+            password: 'testEventManager'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const data = res.getBody();
+        const results = data.results || data;
+        const lunchOptionId = Number(bru.getVar("lunch_option_id"));
+        const target = results.find((item) => item.id === lunchOptionId);
+
+        if (!target) {
+          throw new Error(`Lunch option ${lunchOptionId} not found in event lunch options.`);
+        }
+        if (target.name !== 'Bruno Bento') {
+          throw new Error(`Expected lunch option name Bruno Bento, got ${target.name}`);
+        }
+
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "200"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/32.getMyEventTeamMembers.yml
+++ b/nexus_integration_test/32.getMyEventTeamMembers.yml
@@ -1,0 +1,55 @@
+info:
+  name: 32.getMyEventTeamMembers
+  type: http
+  seq: 34
+
+http:
+  method: GET
+  url: 127.0.0.1:8000/api/v1/event-teams/{{event_team_id}}/members/?user=me
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',
+          {
+            email: 'testEventManager@test.com',
+            password: 'testEventManager'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const data = res.getBody();
+        const results = data.results || data;
+
+        if (!Array.isArray(results) || results.length === 0) {
+          throw new Error('Expected at least one event team member for user=me.');
+        }
+
+        const target = results.find((item) => item.event_team === Number(bru.getVar("event_team_id")));
+
+        if (!target) {
+          throw new Error('Current user membership was not found in event team member list.');
+        }
+        if (target.is_player !== true) {
+          throw new Error('Expected current user membership to be a player.');
+        }
+
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "200"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5

--- a/nexus_integration_test/33.cleanupIntegrationResources.yml
+++ b/nexus_integration_test/33.cleanupIntegrationResources.yml
@@ -1,0 +1,68 @@
+info:
+  name: 33.cleanupIntegrationResources
+  type: http
+  seq: 35
+
+http:
+  method: DELETE
+  url: 127.0.0.1:8000/api/v1/event-teams/{{event_team_id}}/
+  auth:
+    type: bearer
+    token: "{{jwt_access}}"
+
+runtime:
+  scripts:
+    - type: before-request
+      code: |-
+        const axios = require('axios');
+
+        const response = await axios.post(
+          'http://127.0.0.1:8000/api/v1/users/login/',
+          {
+            email: 'testEventManager@test.com',
+            password: 'testEventManager'
+          }
+        );
+        bru.setVar("jwt_access", response.data.access);
+    - type: after-response
+      code: |-
+        const axios = require('axios');
+        const token = bru.getVar("jwt_access");
+        const eventId = bru.getVar("event_id");
+        const teamId = bru.getVar("team_id");
+        const templateId = bru.getVar("template_id");
+
+        const headers = {
+          Authorization: `Bearer ${token}`
+        };
+
+        if (eventId) {
+          await axios.delete(`http://127.0.0.1:8000/api/v1/events/${eventId}/`, { headers });
+        }
+
+        if (teamId) {
+          await axios.delete(`http://127.0.0.1:8000/api/v1/teams/${teamId}/`, { headers });
+        }
+
+        if (templateId) {
+          await axios.delete(`http://127.0.0.1:8000/api/v1/match-templates/${templateId}/`, {
+            headers
+          });
+        }
+
+        bru.setVar("event_team_id", null);
+        bru.setVar("event_id", null);
+        bru.setVar("team_id", null);
+        bru.setVar("template_id", null);
+        bru.setVar("lunch_option_id", null);
+        bru.setVar("jwt_access", null);
+  assertions:
+    - expression: res.status
+      operator: eq
+      value: "204"
+
+settings:
+  encodeUrl: true
+  timeout: 0
+  followRedirects: true
+  maxRedirects: 5


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Extends the Bruno event integration flow with new cross‑module tests for lunch options and team membership, plus automated cleanup. Improves end‑to‑end coverage across events, lunch-options, event-teams, teams, and match-templates.

- **New Features**
  - Create lunch option and assert 201 + name; store `lunch_option_id`.
  - List event lunch options and verify the created option exists.
  - Get team members for `user=me` and assert membership with `is_player=true`.
  - Cleanup step deletes event team and then event, team, and match-template; clears temp vars.
  - Each step logs in as the event manager before request and clears JWT after.

<sup>Written for commit 302f4432c187ff33d60c75fe394a88055d348c3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests for lunch option creation and retrieval
  * Added integration tests for event team member management
  * Added integration test for resource cleanup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->