### PR TITLE
fix: fix dockerfile to prevent service interruption

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -49,6 +49,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 # Default command: Run with Granian
 CMD ["granian", "config.wsgi:application", \
   "--interface", "wsgi", \
+  "--respawn-failed-workers", \
   "--host", "0.0.0.0", \
   "--port", "8000", \
   "--workers", "2", \

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -6,6 +6,7 @@ x-django-template: &django-base
       - GIT_TAG=${GIT_TAG:-latest}
   image: api-image:${GIT_TAG:-latest}
   environment:
+    - RUST_BACKTRACE=full
     - NEXUS_DB_HOST=pg_db_prod
     - NEXUS_DB_PORT=5432
     - REDIS_LOCATION=redis://:${REDIS_PASSWORD}@redis_prod:6379/1
@@ -13,6 +14,8 @@ x-django-template: &django-base
     - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD}@redis_prod:6379/2
     - CELERY_RESULT_BACKEND=redis://:${REDIS_PASSWORD}@redis_prod:6379/3
     - PROD_ALLOW_HOST=${PROD_ALLOW_HOST},django-engine1,django-engine2,api
+
+  restart: unless-stopped
 
   depends_on:
     postgres:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents API interruptions by auto-recovering worker crashes and enabling container restarts in production. Adds full Rust backtraces to improve crash diagnostics.

- **Bug Fixes**
  - Dockerfile: run `granian` with `--respawn-failed-workers` to auto-restart failed workers.
  - Compose (prod): set `restart: unless-stopped` for the API service.
  - Diagnostics: enable `RUST_BACKTRACE=full` for full stack traces.

<sup>Written for commit e114ee4fac5d0c65b53b3d89e17225c2c520e460. Summary will update on new commits. <a href="https://cubic.dev/pr/FriedDinoEggs/Nexus/pull/94?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker API service configuration to automatically respawn failed worker processes, improving service reliability.
  * Configured production services to automatically restart on failure.
  * Enhanced error logging capabilities with full Rust backtrace support for improved troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FriedDinoEggs/Nexus/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->