### PR TITLE
feat: support '/me' shortcut in EventTeamMemberViewSet

### DIFF
--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -3,6 +3,7 @@ from django.db.models import Q
 from drf_spectacular.utils import extend_schema
 from rest_framework import parsers, permissions, serializers, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.generics import get_object_or_404
 from rest_framework.views import Response
 
 from apps.notification.models import Notification
@@ -355,6 +356,18 @@ class EventTeamMemberViewSet(viewsets.ModelViewSet):
                 queryset = queryset.filter(user=user_param)
 
         return queryset
+
+    def get_object(self):
+        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
+        lookup_value = self.kwargs[lookup_url_kwarg]
+
+        if lookup_value == 'me':
+            queryset = self.filter_queryset(self.get_queryset())
+            obj = get_object_or_404(queryset, user=self.request.user)
+            self.check_object_permissions(self.request, obj)
+            return obj
+
+        return super().get_object()
 
     def create(self, request, *args, **kwargs):
         user = None


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a `/me` shortcut to `EventTeamMemberViewSet` detail routes so clients can fetch/update their own team-member record without knowing its ID. Previously clients had to pass a specific ID; now `me` resolves to the current user’s team-member object with the same permission checks.

- Applies to detail endpoints only; list and create behavior is unchanged.
- Uses the filtered queryset and object-level permissions; returns 404 if the current user has no matching team-member record.
- No config or data migration required; clients may call the existing detail route with `me` (e.g., `/events/team-members/me/`).

<sup>Written for commit f9e81981cbc78bc639e0650824b2136607c11851. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FriedDinoEggs/Nexus/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

